### PR TITLE
fix/14/ enable server certificate validation

### DIFF
--- a/Streetcode/Streetcode.WebApi/Utils/WebParsingUtils.cs
+++ b/Streetcode/Streetcode.WebApi/Utils/WebParsingUtils.cs
@@ -57,7 +57,6 @@ public class WebParsingUtils
 
         var clientHandler = new HttpClientHandler();
         clientHandler.AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate;
-        clientHandler.ServerCertificateCustomValidationCallback = (message, cert, chain, errors) => true;
 
         var retryPolicy = Policy.Handle<Exception>().WaitAndRetryAsync(
             3, retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)));


### PR DESCRIPTION
dev
## GitHub Project

* [GitHub Board Ticket](https://github.com/project-studying-dotnet/Streetcode-Server-September/issues/14)


## Code reviewers

- [x] @refokcer 
- [ ] @GrinchArt 

## Summary of issue

Server certificate validation was disabled by defining custom callback function that always returns true. This means that all SSL certificates will be accepted, even if they are invalid, expired, or self-signed. This expose app to man-in-the-middle attacks and other vulnerabilities.

## Summary of change

Remove custom callback function and rely on default validation implementation by Microsoft. This is also recomended by SonarCloud.

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions

Closes issue #14 