### PR TITLE
fix/51/ extract admin credentials into user secrets

### DIFF
--- a/Streetcode/Streetcode.DAL/Entities/AdditionalContent/AdminConfiguration.cs
+++ b/Streetcode/Streetcode.DAL/Entities/AdditionalContent/AdminConfiguration.cs
@@ -1,0 +1,13 @@
+using Streetcode.DAL.Enums;
+
+namespace Streetcode.DAL.Entities.AdditionalContent;
+
+public class AdminConfiguration
+{
+    public string Name { get; set; } = null!;
+    public string Surname { get; set; } = null!;
+    public string Email { get; set; } = null!;
+    public string Login { get; set; } = null!;
+    public string Password { get; set; } = null!;
+    public UserRole Role { get; set; }
+}

--- a/Streetcode/Streetcode.WebApi/Extensions/SeedingLocalExtension.cs
+++ b/Streetcode/Streetcode.WebApi/Extensions/SeedingLocalExtension.cs
@@ -35,6 +35,8 @@ namespace Streetcode.WebApi.Extensions
                 var blobService = new BlobService(blobOptions, repo);
                 string initialDataImagePath = "../Streetcode.DAL/InitialData/images.json";
                 string initialDataAudioPath = "../Streetcode.DAL/InitialData/audios.json";
+                var adminConfig = app.Configuration.GetSection(nameof(AdminConfiguration)).Get<AdminConfiguration>();
+                
                 if (!dbContext.Images.Any())
                 {
                     string imageJson = File.ReadAllText(initialDataImagePath, Encoding.UTF8);
@@ -272,12 +274,12 @@ namespace Streetcode.WebApi.Extensions
                         dbContext.Users.AddRange(
                             new DAL.Entities.Users.User
                             {
-                                Email = "admin",
-                                Role = UserRole.MainAdministrator,
-                                Login = "admin",
-                                Name = "admin",
-                                Password = "admin",
-                                Surname = "admin",
+                                Email = adminConfig.Email,
+                                Role = adminConfig.Role,
+                                Login = adminConfig.Login,
+                                Name = adminConfig.Name,
+                                Password = adminConfig.Password,
+                                Surname = adminConfig.Surname,
                             });
 
                         await dbContext.SaveChangesAsync();


### PR DESCRIPTION
dev
## Summary of issue

In `Streetcode.WebApi.Extensions.SeedingLocalExtension.cs` password and other admin creadentials were leaked, that causes security hotspots.

## Summary of change

All admin credentials were extracted into user secrets section. In `SeedDataAsync` all admin info is retrieved and mapped a section of the application's configuration to a stronly-typed AdminConfiguration object.

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=50%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  PR meets all conventions

This PR closes issue #51 