### PR TITLE
refactor/84/ move ef entity configuration to separate classes

### DIFF
--- a/Streetcode/Streetcode.DAL/Persistence/Configurations/AdditionalContent/Coordinates/CoordinateConfiguration.cs
+++ b/Streetcode/Streetcode.DAL/Persistence/Configurations/AdditionalContent/Coordinates/CoordinateConfiguration.cs
@@ -1,0 +1,17 @@
+namespace Streetcode.DAL.Persistence.Configurations.AdditionalContent.Coordinates;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Entities.AdditionalContent.Coordinates;
+using Entities.AdditionalContent.Coordinates.Types;
+
+public class CoordinateConfiguration: IEntityTypeConfiguration<Coordinate>
+{
+    public void Configure(EntityTypeBuilder<Coordinate> builder)
+    {
+        builder.HasDiscriminator<string>("CoordinateType")
+            .HasValue<Coordinate>("coordinate_base")
+            .HasValue<StreetcodeCoordinate>("coordinate_streetcode")
+            .HasValue<ToponymCoordinate>("coordinate_toponym");
+    }
+}

--- a/Streetcode/Streetcode.DAL/Persistence/Configurations/AdditionalContent/StreetcodeTagIndexConfiguration.cs
+++ b/Streetcode/Streetcode.DAL/Persistence/Configurations/AdditionalContent/StreetcodeTagIndexConfiguration.cs
@@ -1,0 +1,13 @@
+namespace Streetcode.DAL.Persistence.Configurations.AdditionalContent;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Entities.AdditionalContent;
+
+public class StreetcodeTagIndexConfiguration: IEntityTypeConfiguration<StreetcodeTagIndex>
+{
+    public void Configure(EntityTypeBuilder<StreetcodeTagIndex> builder)
+    {
+        builder.HasKey(nameof(StreetcodeTagIndex.StreetcodeId), nameof(StreetcodeTagIndex.TagId));
+    }
+}

--- a/Streetcode/Streetcode.DAL/Persistence/Configurations/AdditionalContent/TagConfiguration.cs
+++ b/Streetcode/Streetcode.DAL/Persistence/Configurations/AdditionalContent/TagConfiguration.cs
@@ -1,0 +1,20 @@
+namespace Streetcode.DAL.Persistence.Configurations.AdditionalContent;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Entities.AdditionalContent;
+
+public class TagConfiguration: IEntityTypeConfiguration<Tag>
+{
+    public void Configure(EntityTypeBuilder<Tag> builder)
+    {
+        builder.HasMany(t => t.Streetcodes)
+            .WithMany(s => s.Tags)
+            .UsingEntity<StreetcodeTagIndex>(
+                sp => sp
+                    .HasOne(x => x.Streetcode)
+                    .WithMany(x => x.StreetcodeTagIndices)
+                    .HasForeignKey(x => x.StreetcodeId),
+                sp => sp.HasOne(x => x.Tag).WithMany(x => x.StreetcodeTagIndices).HasForeignKey(x => x.TagId));
+    }
+}

--- a/Streetcode/Streetcode.DAL/Persistence/Configurations/Analytics/StatisticRecordConfiguration.cs
+++ b/Streetcode/Streetcode.DAL/Persistence/Configurations/Analytics/StatisticRecordConfiguration.cs
@@ -1,0 +1,15 @@
+namespace Streetcode.DAL.Persistence.Configurations.Analytics;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Entities.Analytics;
+
+public class StatisticRecordConfiguration: IEntityTypeConfiguration<StatisticRecord>
+{
+    public void Configure(EntityTypeBuilder<StatisticRecord> builder)
+    {
+        builder.HasOne(x => x.StreetcodeCoordinate)
+            .WithOne(x => x.StatisticRecord)
+            .HasForeignKey<StatisticRecord>(x => x.StreetcodeCoordinateId);
+    }
+}

--- a/Streetcode/Streetcode.DAL/Persistence/Configurations/Media/Images/ImageConfiguration.cs
+++ b/Streetcode/Streetcode.DAL/Persistence/Configurations/Media/Images/ImageConfiguration.cs
@@ -1,0 +1,37 @@
+namespace Streetcode.DAL.Persistence.Configurations.Media.Images;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Entities.Media.Images;
+using Entities.Partners;
+
+public class ImageConfiguration: IEntityTypeConfiguration<Image>
+{
+    public void Configure(EntityTypeBuilder<Image> builder)
+    {
+        builder.HasOne(d => d.Art)
+            .WithOne(a => a.Image)
+            .HasForeignKey<Art>(a => a.ImageId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasOne(im => im.ImageDetails)
+            .WithOne(info => info.Image)
+            .HasForeignKey<ImageDetails>(a => a.ImageId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasOne(d => d.Partner)
+            .WithOne(p => p.Logo)
+            .HasForeignKey<Partner>(d => d.LogoId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasMany(d => d.Facts)
+            .WithOne(p => p.Image)
+            .HasForeignKey(d => d.ImageId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasMany(i => i.SourceLinkCategories)
+            .WithOne(s => s.Image)
+            .HasForeignKey(d => d.ImageId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/Streetcode/Streetcode.DAL/Persistence/Configurations/News/NewsConfiguration.cs
+++ b/Streetcode/Streetcode.DAL/Persistence/Configurations/News/NewsConfiguration.cs
@@ -1,0 +1,15 @@
+namespace Streetcode.DAL.Persistence.Configurations.News;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Entities.News;
+
+public class NewsConfiguration: IEntityTypeConfiguration<News>
+{
+    public void Configure(EntityTypeBuilder<News> builder)
+    {
+        builder.HasOne(x => x.Image)
+            .WithOne(x => x.News)
+            .HasForeignKey<News>(x => x.ImageId);
+    }
+}

--- a/Streetcode/Streetcode.DAL/Persistence/Configurations/Partners/PartnerConfiguration.cs
+++ b/Streetcode/Streetcode.DAL/Persistence/Configurations/Partners/PartnerConfiguration.cs
@@ -1,0 +1,19 @@
+namespace Streetcode.DAL.Persistence.Configurations.Partners;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Entities.Partners;
+
+public class PartnerConfiguration: IEntityTypeConfiguration<Partner>
+{
+    public void Configure(EntityTypeBuilder<Partner> builder)
+    {
+        builder.HasMany(d => d.PartnerSourceLinks)
+            .WithOne(p => p.Partner)
+            .HasForeignKey(d => d.PartnerId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.Property(p => p.IsKeyPartner)
+            .HasDefaultValue("false");
+    }
+}

--- a/Streetcode/Streetcode.DAL/Persistence/Configurations/Sources/SourceLinkCategoryConfiguration.cs
+++ b/Streetcode/Streetcode.DAL/Persistence/Configurations/Sources/SourceLinkCategoryConfiguration.cs
@@ -1,0 +1,16 @@
+namespace Streetcode.DAL.Persistence.Configurations.Sources;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Entities.Sources;
+
+public class SourceLinkCategoryConfiguration: IEntityTypeConfiguration<SourceLinkCategory>
+{
+    public void Configure(EntityTypeBuilder<SourceLinkCategory> builder)
+    {
+        builder.HasMany(d => d.StreetcodeCategoryContents)
+            .WithOne(p => p.SourceLinkCategory)
+            .HasForeignKey(d => d.SourceLinkCategoryId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/Streetcode/Streetcode.DAL/Persistence/Configurations/Streetcode/RelatedFigureConfiguration.cs
+++ b/Streetcode/Streetcode.DAL/Persistence/Configurations/Streetcode/RelatedFigureConfiguration.cs
@@ -1,0 +1,23 @@
+namespace Streetcode.DAL.Persistence.Configurations.Streetcode;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Entities.Streetcode;
+
+public class RelatedFigureConfiguration: IEntityTypeConfiguration<RelatedFigure>
+{
+    public void Configure(EntityTypeBuilder<RelatedFigure> builder)
+    {
+        builder.HasKey(d => new { d.ObserverId, d.TargetId });
+
+        builder.HasOne(d => d.Observer)
+            .WithMany(d => d.Observers)
+            .HasForeignKey(d => d.ObserverId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne(d => d.Target)
+            .WithMany(d => d.Targets)
+            .HasForeignKey(d => d.TargetId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/Streetcode/Streetcode.DAL/Persistence/Configurations/Streetcode/StreetcodeArtConfiguration.cs
+++ b/Streetcode/Streetcode.DAL/Persistence/Configurations/Streetcode/StreetcodeArtConfiguration.cs
@@ -1,0 +1,29 @@
+namespace Streetcode.DAL.Persistence.Configurations.Streetcode;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Entities.Streetcode;
+
+public class StreetcodeArtConfiguration: IEntityTypeConfiguration<StreetcodeArt>
+{
+    public void Configure(EntityTypeBuilder<StreetcodeArt> builder)
+    {
+        builder.HasKey(d => new { d.ArtId, d.StreetcodeId });
+
+        builder.HasOne(d => d.Streetcode)
+            .WithMany(d => d.StreetcodeArts)
+            .HasForeignKey(d => d.StreetcodeId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasOne(d => d.Art)
+            .WithMany(d => d.StreetcodeArts)
+            .HasForeignKey(d => d.ArtId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.Property(e => e.Index)
+            .HasDefaultValue(1);
+
+        builder.HasIndex(d => new { d.ArtId, d.StreetcodeId })
+            .IsUnique(false);
+    }
+}

--- a/Streetcode/Streetcode.DAL/Persistence/Configurations/Streetcode/StreetcodeContentConfiguration.cs
+++ b/Streetcode/Streetcode.DAL/Persistence/Configurations/Streetcode/StreetcodeContentConfiguration.cs
@@ -1,0 +1,100 @@
+namespace Streetcode.DAL.Persistence.Configurations.Streetcode;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Entities.Media.Images;
+using Entities.Partners;
+using Entities.Sources;
+using Entities.Streetcode;
+using Entities.Streetcode.TextContent;
+using Entities.Streetcode.Types;
+using Entities.Toponyms;
+using Entities.Transactions;
+using Enums;
+
+public class StreetcodeContentConfiguration: IEntityTypeConfiguration<StreetcodeContent>
+{
+    public void Configure(EntityTypeBuilder<StreetcodeContent> builder)
+    {
+        builder.Property(s => s.CreatedAt)
+                .HasDefaultValueSql("GETDATE()");
+
+            builder.Property(s => s.UpdatedAt)
+                .HasDefaultValueSql("GETDATE()");
+
+            builder.Property(s => s.ViewCount)
+                .HasDefaultValue(0);
+
+            builder.HasDiscriminator<string>(StreetcodeTypeDiscriminators.DiscriminatorName)
+                .HasValue<StreetcodeContent>(StreetcodeTypeDiscriminators.StreetcodeBaseType)
+                .HasValue<PersonStreetcode>(StreetcodeTypeDiscriminators.StreetcodePersonType)
+                .HasValue<EventStreetcode>(StreetcodeTypeDiscriminators.StreetcodeEventType);
+
+            builder.Property<string>("StreetcodeType").Metadata.SetAfterSaveBehavior(PropertySaveBehavior.Save);
+
+            builder.HasMany(d => d.Coordinates)
+                .WithOne(c => c.Streetcode)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            builder.HasMany(d => d.Facts)
+                .WithOne(f => f.Streetcode)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            builder.HasMany(d => d.Images)
+                .WithMany(i => i.Streetcodes)
+                .UsingEntity<StreetcodeImage>(
+                    si => si.HasOne(i => i.Image).WithMany().HasForeignKey(i => i.ImageId),
+                    si => si.HasOne(i => i.Streetcode).WithMany().HasForeignKey(i => i.StreetcodeId))
+                .ToTable("streetcode_image", "streetcode");
+
+            builder.HasMany(d => d.TimelineItems)
+                .WithOne(t => t.Streetcode)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            builder.HasMany(d => d.Toponyms)
+                .WithMany(t => t.Streetcodes)
+                .UsingEntity<StreetcodeToponym>(
+                    st => st.HasOne(s => s.Toponym).WithMany().HasForeignKey(x => x.ToponymId),
+                    st => st.HasOne(s => s.Streetcode).WithMany().HasForeignKey(x => x.StreetcodeId))
+                .ToTable("streetcode_toponym", "streetcode");
+
+            builder.HasMany(d => d.SourceLinkCategories)
+                    .WithMany(c => c.Streetcodes)
+                    .UsingEntity<StreetcodeCategoryContent>(
+                        scat => scat.HasOne(i => i.SourceLinkCategory).WithMany(s => s.StreetcodeCategoryContents).HasForeignKey(i => i.SourceLinkCategoryId),
+                        scat => scat.HasOne(i => i.Streetcode).WithMany(s => s.StreetcodeCategoryContents).HasForeignKey(i => i.StreetcodeId))
+                    .ToTable("streetcode_source_link_categories", "sources");
+
+            builder.HasMany(d => d.Partners)
+                    .WithMany(p => p.Streetcodes)
+                    .UsingEntity<StreetcodePartner>(
+                        sp => sp.HasOne(i => i.Partner).WithMany().HasForeignKey(x => x.PartnerId),
+                        sp => sp.HasOne(i => i.Streetcode).WithMany().HasForeignKey(x => x.StreetcodeId))
+                   .ToTable("streetcode_partners", "streetcode");
+
+            builder.HasMany(d => d.Videos)
+                    .WithOne(p => p.Streetcode)
+                    .HasForeignKey(d => d.StreetcodeId)
+                    .OnDelete(DeleteBehavior.Cascade);
+
+            builder.HasOne(d => d.Audio)
+                    .WithOne(p => p.Streetcode)
+                    .OnDelete(DeleteBehavior.Cascade);
+
+            builder.HasOne(d => d.Text)
+                    .WithOne(p => p.Streetcode)
+                    .HasForeignKey<Text>(d => d.StreetcodeId)
+                    .OnDelete(DeleteBehavior.Cascade);
+
+            builder.HasOne(d => d.TransactionLink)
+                    .WithOne(p => p.Streetcode)
+                    .HasForeignKey<TransactionLink>(d => d.StreetcodeId)
+                    .OnDelete(DeleteBehavior.Cascade);
+
+            builder.HasMany(d => d.StatisticRecords)
+                    .WithOne(t => t.Streetcode)
+                    .HasForeignKey(t => t.StreetcodeId)
+                    .OnDelete(DeleteBehavior.NoAction);
+    }
+}

--- a/Streetcode/Streetcode.DAL/Persistence/Configurations/Streetcode/TextContent/RelatedTermConfiguration.cs
+++ b/Streetcode/Streetcode.DAL/Persistence/Configurations/Streetcode/TextContent/RelatedTermConfiguration.cs
@@ -1,0 +1,15 @@
+namespace Streetcode.DAL.Persistence.Configurations.Streetcode.TextContent;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Entities.Streetcode.TextContent;
+
+public class RelatedTermConfiguration: IEntityTypeConfiguration<RelatedTerm>
+{
+    public void Configure(EntityTypeBuilder<RelatedTerm> builder)
+    {
+        builder.HasOne(rt => rt.Term)
+            .WithMany(t => t.RelatedTerms)
+            .HasForeignKey(rt => rt.TermId);
+    }
+}

--- a/Streetcode/Streetcode.DAL/Persistence/Configurations/Team/TeamMemberConfiguration.cs
+++ b/Streetcode/Streetcode.DAL/Persistence/Configurations/Team/TeamMemberConfiguration.cs
@@ -1,0 +1,25 @@
+namespace Streetcode.DAL.Persistence.Configurations.Team;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Entities.Team;
+
+public class TeamMemberConfiguration: IEntityTypeConfiguration<TeamMember>
+{
+    public void Configure(EntityTypeBuilder<TeamMember> builder)
+    {
+        builder.HasOne(x => x.Image)
+            .WithOne(x => x.TeamMember)
+            .HasForeignKey<TeamMember>(x => x.ImageId);
+
+        builder.HasMany(x => x.Positions)
+            .WithMany(x => x.TeamMembers)
+            .UsingEntity<TeamMemberPositions>(
+                tp => tp.HasOne(x => x.Positions).WithMany().HasForeignKey(x => x.PositionsId),
+                tp => tp.HasOne(x => x.TeamMember).WithMany().HasForeignKey(x => x.TeamMemberId));
+        
+        builder.HasMany(x => x.TeamMemberLinks)
+            .WithOne(x => x.TeamMember)
+            .HasForeignKey(x => x.TeamMemberId);
+    }
+}

--- a/Streetcode/Streetcode.DAL/Persistence/Configurations/Team/TeamMemberPositionsConfiguration.cs
+++ b/Streetcode/Streetcode.DAL/Persistence/Configurations/Team/TeamMemberPositionsConfiguration.cs
@@ -1,0 +1,13 @@
+namespace Streetcode.DAL.Persistence.Configurations.Team;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Entities.Team;
+
+public class TeamMemberPositionsConfiguration: IEntityTypeConfiguration<TeamMemberPositions>
+{
+    public void Configure(EntityTypeBuilder<TeamMemberPositions> builder)
+    {
+        builder.HasKey(nameof(TeamMemberPositions.TeamMemberId), nameof(TeamMemberPositions.PositionsId));
+    }
+}

--- a/Streetcode/Streetcode.DAL/Persistence/Configurations/Timeline/HistoricalContextTimelineConfiguration.cs
+++ b/Streetcode/Streetcode.DAL/Persistence/Configurations/Timeline/HistoricalContextTimelineConfiguration.cs
@@ -1,0 +1,21 @@
+namespace Streetcode.DAL.Persistence.Configurations.Timeline;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Entities.Timeline;
+
+public class HistoricalContextTimelineConfiguration: IEntityTypeConfiguration<HistoricalContextTimeline>
+{
+    public void Configure(EntityTypeBuilder<HistoricalContextTimeline> builder)
+    {
+        builder.HasKey(ht => new { ht.TimelineId, ht.HistoricalContextId });
+        
+        builder.HasOne(ht => ht.Timeline)
+            .WithMany(x => x.HistoricalContextTimelines)
+            .HasForeignKey(x => x.TimelineId);
+        
+        builder.HasOne(ht => ht.HistoricalContext)
+            .WithMany(x => x.HistoricalContextTimelines)
+            .HasForeignKey(x => x.HistoricalContextId);
+    }
+}

--- a/Streetcode/Streetcode.DAL/Persistence/Configurations/Toponyms/ToponymConfiguration.cs
+++ b/Streetcode/Streetcode.DAL/Persistence/Configurations/Toponyms/ToponymConfiguration.cs
@@ -1,0 +1,15 @@
+namespace Streetcode.DAL.Persistence.Configurations.Toponyms;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Entities.Toponyms;
+
+public class ToponymConfiguration: IEntityTypeConfiguration<Toponym>
+{
+    public void Configure(EntityTypeBuilder<Toponym> builder)
+    {
+        builder.HasOne(d => d.Coordinate)
+            .WithOne(p => p.Toponym)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/Streetcode/Streetcode.DAL/Persistence/StreetcodeDbContext.cs
+++ b/Streetcode/Streetcode.DAL/Persistence/StreetcodeDbContext.cs
@@ -10,8 +10,8 @@ using Entities.Media.Images;
 using Entities.News;
 using Entities.Partners;
 using Entities.Sources;
-using Streetcode.DAL.Entities.Streetcode;
-using Streetcode.DAL.Entities.Streetcode.TextContent;
+using Entities.Streetcode;
+using Entities.Streetcode.TextContent;
 using Entities.Team;
 using Entities.Timeline;
 using Entities.Toponyms;
@@ -24,8 +24,8 @@ using Configurations.Media.Images;
 using Configurations.News;
 using Configurations.Partners;
 using Configurations.Sources;
-using Streetcode.DAL.Persistence.Configurations.Streetcode;
-using Streetcode.DAL.Persistence.Configurations.Streetcode.TextContent;
+using Configurations.Streetcode;
+using Configurations.Streetcode.TextContent;
 using Configurations.Team;
 using Configurations.Timeline;
 using Configurations.Toponyms;
@@ -83,22 +83,6 @@ public class StreetcodeDbContext : DbContext
         base.OnModelCreating(modelBuilder);
 
         modelBuilder.UseCollation("SQL_Ukrainian_CP1251_CI_AS");
-
-        modelBuilder.ApplyConfiguration(new StatisticRecordConfiguration());
-        modelBuilder.ApplyConfiguration(new NewsConfiguration());
-        modelBuilder.ApplyConfiguration(new TeamMemberConfiguration());
-        modelBuilder.ApplyConfiguration(new TeamMemberPositionsConfiguration());
-        modelBuilder.ApplyConfiguration(new TagConfiguration());
-        modelBuilder.ApplyConfiguration(new StreetcodeTagIndexConfiguration());
-        modelBuilder.ApplyConfiguration(new ToponymConfiguration());
-        modelBuilder.ApplyConfiguration(new PartnerConfiguration());
-        modelBuilder.ApplyConfiguration(new HistoricalContextTimelineConfiguration());
-        modelBuilder.ApplyConfiguration(new SourceLinkCategoryConfiguration());
-        modelBuilder.ApplyConfiguration(new ImageConfiguration());
-        modelBuilder.ApplyConfiguration(new RelatedFigureConfiguration());
-        modelBuilder.ApplyConfiguration(new StreetcodeArtConfiguration());
-        modelBuilder.ApplyConfiguration(new StreetcodeContentConfiguration());
-        modelBuilder.ApplyConfiguration(new RelatedTermConfiguration());
-        modelBuilder.ApplyConfiguration(new CoordinateConfiguration());
+        modelBuilder.ApplyConfigurationsFromAssembly(typeof(StreetcodeDbContext).Assembly);
     }
 }

--- a/Streetcode/Streetcode.DAL/Persistence/StreetcodeDbContext.cs
+++ b/Streetcode/Streetcode.DAL/Persistence/StreetcodeDbContext.cs
@@ -17,18 +17,6 @@ using Entities.Timeline;
 using Entities.Toponyms;
 using Entities.Transactions;
 using Entities.Users;
-using Configurations.AdditionalContent;
-using Configurations.AdditionalContent.Coordinates;
-using Configurations.Analytics;
-using Configurations.Media.Images;
-using Configurations.News;
-using Configurations.Partners;
-using Configurations.Sources;
-using Configurations.Streetcode;
-using Configurations.Streetcode.TextContent;
-using Configurations.Team;
-using Configurations.Timeline;
-using Configurations.Toponyms;
 
 public class StreetcodeDbContext : DbContext
 {

--- a/Streetcode/Streetcode.DAL/Persistence/StreetcodeDbContext.cs
+++ b/Streetcode/Streetcode.DAL/Persistence/StreetcodeDbContext.cs
@@ -1,26 +1,34 @@
+namespace Streetcode.DAL.Persistence;
+
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Metadata;
-using Streetcode.DAL.Entities.AdditionalContent;
-using Streetcode.DAL.Entities.AdditionalContent.Coordinates;
-using Streetcode.DAL.Entities.AdditionalContent.Coordinates.Types;
-using Streetcode.DAL.Entities.Analytics;
-using Streetcode.DAL.Entities.Feedback;
-using Streetcode.DAL.Entities.Media;
-using Streetcode.DAL.Entities.Media.Images;
-using Streetcode.DAL.Entities.News;
-using Streetcode.DAL.Entities.Partners;
-using Streetcode.DAL.Entities.Sources;
+using Entities.AdditionalContent;
+using Entities.AdditionalContent.Coordinates.Types;
+using Entities.Analytics;
+using Entities.Feedback;
+using Entities.Media;
+using Entities.Media.Images;
+using Entities.News;
+using Entities.Partners;
+using Entities.Sources;
 using Streetcode.DAL.Entities.Streetcode;
 using Streetcode.DAL.Entities.Streetcode.TextContent;
-using Streetcode.DAL.Entities.Streetcode.Types;
-using Streetcode.DAL.Entities.Team;
-using Streetcode.DAL.Entities.Timeline;
-using Streetcode.DAL.Entities.Toponyms;
-using Streetcode.DAL.Entities.Transactions;
-using Streetcode.DAL.Entities.Users;
-using Streetcode.DAL.Enums;
-
-namespace Streetcode.DAL.Persistence;
+using Entities.Team;
+using Entities.Timeline;
+using Entities.Toponyms;
+using Entities.Transactions;
+using Entities.Users;
+using Configurations.AdditionalContent;
+using Configurations.AdditionalContent.Coordinates;
+using Configurations.Analytics;
+using Configurations.Media.Images;
+using Configurations.News;
+using Configurations.Partners;
+using Configurations.Sources;
+using Streetcode.DAL.Persistence.Configurations.Streetcode;
+using Streetcode.DAL.Persistence.Configurations.Streetcode.TextContent;
+using Configurations.Team;
+using Configurations.Timeline;
+using Configurations.Toponyms;
 
 public class StreetcodeDbContext : DbContext
 {
@@ -76,236 +84,21 @@ public class StreetcodeDbContext : DbContext
 
         modelBuilder.UseCollation("SQL_Ukrainian_CP1251_CI_AS");
 
-        modelBuilder.Entity<StatisticRecord>()
-              .HasOne(x => x.StreetcodeCoordinate)
-              .WithOne(x => x.StatisticRecord)
-              .HasForeignKey<StatisticRecord>(x => x.StreetcodeCoordinateId);
-
-        modelBuilder.Entity<News>()
-            .HasOne(x => x.Image)
-            .WithOne(x => x.News)
-            .HasForeignKey<News>(x => x.ImageId);
-
-        modelBuilder.Entity<TeamMember>()
-            .HasOne(x => x.Image)
-            .WithOne(x => x.TeamMember)
-            .HasForeignKey<TeamMember>(x => x.ImageId);
-
-        modelBuilder.Entity<TeamMember>()
-            .HasMany(x => x.Positions)
-            .WithMany(x => x.TeamMembers)
-            .UsingEntity<TeamMemberPositions>(
-            tp => tp.HasOne(x => x.Positions).WithMany().HasForeignKey(x => x.PositionsId),
-            tp => tp.HasOne(x => x.TeamMember).WithMany().HasForeignKey(x => x.TeamMemberId));
-
-        modelBuilder.Entity<TeamMember>()
-            .HasMany(x => x.TeamMemberLinks)
-            .WithOne(x => x.TeamMember)
-            .HasForeignKey(x => x.TeamMemberId);
-
-        modelBuilder.Entity<TeamMemberPositions>()
-            .HasKey(nameof(TeamMemberPositions.TeamMemberId), nameof(TeamMemberPositions.PositionsId));
-
-        modelBuilder.Entity<Tag>()
-            .HasMany(t => t.Streetcodes)
-            .WithMany(s => s.Tags)
-            .UsingEntity<StreetcodeTagIndex>(
-            sp => sp.HasOne(x => x.Streetcode).WithMany(x => x.StreetcodeTagIndices).HasForeignKey(x => x.StreetcodeId),
-            sp => sp.HasOne(x => x.Tag).WithMany(x => x.StreetcodeTagIndices).HasForeignKey(x => x.TagId));
-
-        modelBuilder.Entity<StreetcodeTagIndex>()
-           .HasKey(nameof(StreetcodeTagIndex.StreetcodeId), nameof(StreetcodeTagIndex.TagId));
-
-        modelBuilder.Entity<Toponym>()
-            .HasOne(d => d.Coordinate)
-            .WithOne(p => p.Toponym)
-            .OnDelete(DeleteBehavior.Cascade);
-
-        modelBuilder.Entity<Partner>(entity =>
-        {
-            entity.HasMany(d => d.PartnerSourceLinks)
-                .WithOne(p => p.Partner)
-                .HasForeignKey(d => d.PartnerId)
-                .OnDelete(DeleteBehavior.Cascade);
-
-            entity.Property(p => p.IsKeyPartner)
-                .HasDefaultValue("false");
-        });
-
-        modelBuilder.Entity<HistoricalContextTimeline>()
-             .HasKey(ht => new { ht.TimelineId, ht.HistoricalContextId });
-        modelBuilder.Entity<HistoricalContextTimeline>()
-            .HasOne(ht => ht.Timeline)
-            .WithMany(x => x.HistoricalContextTimelines)
-            .HasForeignKey(x => x.TimelineId);
-        modelBuilder.Entity<HistoricalContextTimeline>()
-            .HasOne(ht => ht.HistoricalContext)
-            .WithMany(x => x.HistoricalContextTimelines)
-            .HasForeignKey(x => x.HistoricalContextId);
-
-        modelBuilder.Entity<SourceLinkCategory>()
-            .HasMany(d => d.StreetcodeCategoryContents)
-            .WithOne(p => p.SourceLinkCategory)
-            .HasForeignKey(d => d.SourceLinkCategoryId)
-            .OnDelete(DeleteBehavior.Cascade);
-
-        modelBuilder.Entity<Image>(entity =>
-        {
-            entity.HasOne(d => d.Art)
-                .WithOne(a => a.Image)
-                .HasForeignKey<Art>(a => a.ImageId)
-                .OnDelete(DeleteBehavior.Cascade);
-
-            entity.HasOne(im => im.ImageDetails)
-                .WithOne(info => info.Image)
-                .HasForeignKey<ImageDetails>(a => a.ImageId)
-                .OnDelete(DeleteBehavior.Cascade);
-
-            entity.HasOne(d => d.Partner)
-                .WithOne(p => p.Logo)
-                .HasForeignKey<Partner>(d => d.LogoId)
-                .OnDelete(DeleteBehavior.Cascade);
-
-            entity.HasMany(d => d.Facts)
-                .WithOne(p => p.Image)
-                .HasForeignKey(d => d.ImageId)
-                .OnDelete(DeleteBehavior.Cascade);
-
-            entity.HasMany(i => i.SourceLinkCategories)
-                .WithOne(s => s.Image)
-                .HasForeignKey(d => d.ImageId)
-                .OnDelete(DeleteBehavior.Cascade);
-        });
-
-        modelBuilder.Entity<RelatedFigure>(entity =>
-        {
-            entity.HasKey(d => new { d.ObserverId, d.TargetId });
-
-            entity.HasOne(d => d.Observer)
-                .WithMany(d => d.Observers)
-                .HasForeignKey(d => d.ObserverId)
-                .OnDelete(DeleteBehavior.Restrict);
-
-            entity.HasOne(d => d.Target)
-                .WithMany(d => d.Targets)
-                .HasForeignKey(d => d.TargetId)
-                .OnDelete(DeleteBehavior.Cascade);
-        });
-
-        modelBuilder.Entity<StreetcodeArt>(entity =>
-        {
-            entity.HasKey(d => new { d.ArtId, d.StreetcodeId });
-
-            entity.HasOne(d => d.Streetcode)
-                .WithMany(d => d.StreetcodeArts)
-                .HasForeignKey(d => d.StreetcodeId)
-                .OnDelete(DeleteBehavior.Cascade);
-
-            entity.HasOne(d => d.Art)
-                .WithMany(d => d.StreetcodeArts)
-                .HasForeignKey(d => d.ArtId)
-                .OnDelete(DeleteBehavior.Cascade);
-
-            entity.Property(e => e.Index)
-                .HasDefaultValue(1);
-
-            entity
-                .HasIndex(d => new { d.ArtId, d.StreetcodeId })
-                .IsUnique(false);
-        });
-
-        modelBuilder.Entity<StreetcodeContent>(entity =>
-        {
-            entity.Property(s => s.CreatedAt)
-                .HasDefaultValueSql("GETDATE()");
-
-            entity.Property(s => s.UpdatedAt)
-                .HasDefaultValueSql("GETDATE()");
-
-            entity.Property(s => s.ViewCount)
-                .HasDefaultValue(0);
-
-            entity.HasDiscriminator<string>(StreetcodeTypeDiscriminators.DiscriminatorName)
-                .HasValue<StreetcodeContent>(StreetcodeTypeDiscriminators.StreetcodeBaseType)
-                .HasValue<PersonStreetcode>(StreetcodeTypeDiscriminators.StreetcodePersonType)
-                .HasValue<EventStreetcode>(StreetcodeTypeDiscriminators.StreetcodeEventType);
-
-            entity.Property<string>("StreetcodeType").Metadata.SetAfterSaveBehavior(PropertySaveBehavior.Save);
-
-            entity.HasMany(d => d.Coordinates)
-                .WithOne(c => c.Streetcode)
-                .OnDelete(DeleteBehavior.Cascade);
-
-            entity.HasMany(d => d.Facts)
-                .WithOne(f => f.Streetcode)
-                .OnDelete(DeleteBehavior.Cascade);
-
-            entity.HasMany(d => d.Images)
-                .WithMany(i => i.Streetcodes)
-                .UsingEntity<StreetcodeImage>(
-                    si => si.HasOne(i => i.Image).WithMany().HasForeignKey(i => i.ImageId),
-                    si => si.HasOne(i => i.Streetcode).WithMany().HasForeignKey(i => i.StreetcodeId))
-                .ToTable("streetcode_image", "streetcode");
-
-            entity.HasMany(d => d.TimelineItems)
-                .WithOne(t => t.Streetcode)
-                .OnDelete(DeleteBehavior.Cascade);
-
-            entity.HasMany(d => d.Toponyms)
-                .WithMany(t => t.Streetcodes)
-                .UsingEntity<StreetcodeToponym>(
-                    st => st.HasOne(s => s.Toponym).WithMany().HasForeignKey(x => x.ToponymId),
-                    st => st.HasOne(s => s.Streetcode).WithMany().HasForeignKey(x => x.StreetcodeId))
-                .ToTable("streetcode_toponym", "streetcode");
-
-            entity.HasMany(d => d.SourceLinkCategories)
-                    .WithMany(c => c.Streetcodes)
-                    .UsingEntity<StreetcodeCategoryContent>(
-                        scat => scat.HasOne(i => i.SourceLinkCategory).WithMany(s => s.StreetcodeCategoryContents).HasForeignKey(i => i.SourceLinkCategoryId),
-                        scat => scat.HasOne(i => i.Streetcode).WithMany(s => s.StreetcodeCategoryContents).HasForeignKey(i => i.StreetcodeId))
-                    .ToTable("streetcode_source_link_categories", "sources");
-
-            entity.HasMany(d => d.Partners)
-                    .WithMany(p => p.Streetcodes)
-                    .UsingEntity<StreetcodePartner>(
-                        sp => sp.HasOne(i => i.Partner).WithMany().HasForeignKey(x => x.PartnerId),
-                        sp => sp.HasOne(i => i.Streetcode).WithMany().HasForeignKey(x => x.StreetcodeId))
-                   .ToTable("streetcode_partners", "streetcode");
-
-            entity.HasMany(d => d.Videos)
-                    .WithOne(p => p.Streetcode)
-                    .HasForeignKey(d => d.StreetcodeId)
-                    .OnDelete(DeleteBehavior.Cascade);
-
-            entity.HasOne(d => d.Audio)
-                    .WithOne(p => p.Streetcode)
-                    .OnDelete(DeleteBehavior.Cascade);
-
-            entity.HasOne(d => d.Text)
-                    .WithOne(p => p.Streetcode)
-                    .HasForeignKey<Text>(d => d.StreetcodeId)
-                    .OnDelete(DeleteBehavior.Cascade);
-
-            entity.HasOne(d => d.TransactionLink)
-                    .WithOne(p => p.Streetcode)
-                    .HasForeignKey<TransactionLink>(d => d.StreetcodeId)
-                    .OnDelete(DeleteBehavior.Cascade);
-
-            entity.HasMany(d => d.StatisticRecords)
-                    .WithOne(t => t.Streetcode)
-                    .HasForeignKey(t => t.StreetcodeId)
-                    .OnDelete(DeleteBehavior.NoAction);
-        });
-
-        modelBuilder.Entity<RelatedTerm>()
-            .HasOne(rt => rt.Term)
-            .WithMany(t => t.RelatedTerms)
-            .HasForeignKey(rt => rt.TermId);
-
-        modelBuilder.Entity<Coordinate>()
-            .HasDiscriminator<string>("CoordinateType")
-            .HasValue<Coordinate>("coordinate_base")
-            .HasValue<StreetcodeCoordinate>("coordinate_streetcode")
-            .HasValue<ToponymCoordinate>("coordinate_toponym");
+        modelBuilder.ApplyConfiguration(new StatisticRecordConfiguration());
+        modelBuilder.ApplyConfiguration(new NewsConfiguration());
+        modelBuilder.ApplyConfiguration(new TeamMemberConfiguration());
+        modelBuilder.ApplyConfiguration(new TeamMemberPositionsConfiguration());
+        modelBuilder.ApplyConfiguration(new TagConfiguration());
+        modelBuilder.ApplyConfiguration(new StreetcodeTagIndexConfiguration());
+        modelBuilder.ApplyConfiguration(new ToponymConfiguration());
+        modelBuilder.ApplyConfiguration(new PartnerConfiguration());
+        modelBuilder.ApplyConfiguration(new HistoricalContextTimelineConfiguration());
+        modelBuilder.ApplyConfiguration(new SourceLinkCategoryConfiguration());
+        modelBuilder.ApplyConfiguration(new ImageConfiguration());
+        modelBuilder.ApplyConfiguration(new RelatedFigureConfiguration());
+        modelBuilder.ApplyConfiguration(new StreetcodeArtConfiguration());
+        modelBuilder.ApplyConfiguration(new StreetcodeContentConfiguration());
+        modelBuilder.ApplyConfiguration(new RelatedTermConfiguration());
+        modelBuilder.ApplyConfiguration(new CoordinateConfiguration());
     }
 }


### PR DESCRIPTION
dev

## Summary of issue
All entity configurations for EF Core were set in `StreetcodeDbContext.OnModelCreating` method. This method was large, 
unreadable and hard to maintain.

## Summary of change
Configuration for every entity was extracted into separate class `<ModelName>Configuration` that implements `IEntityTypeConfiguration` generic interface. These classes overrides interface's method `Configure` in which all configuration for specified entity is set. 
In `StreetcodeDbContext.OnModelCreating` these configurations are applied by providing configuration class instances to `modelbuilder.ApplyConfiguration` method.
Configuration classes are placed in appropriate directories inside of `Streetcode.DAL.Persistence.Configurations` and follows structure of `Streetcode.DAL.Entities` directory.

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=50%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  PR meets all conventions

This PR closes issue #84 