### PR TITLE
feat/102/implement create source link feature

### DIFF
--- a/Streetcode/Streetcode.BLL/Dto/Sources/SourceLinkCategoryCreateDto.cs
+++ b/Streetcode/Streetcode.BLL/Dto/Sources/SourceLinkCategoryCreateDto.cs
@@ -1,0 +1,3 @@
+namespace Streetcode.BLL.Dto.Sources;
+
+public record SourceLinkCategoryCreateDto(string Title, int ImageId);

--- a/Streetcode/Streetcode.BLL/Mapping/Sources/SourceLinkCategoryProfile.cs
+++ b/Streetcode/Streetcode.BLL/Mapping/Sources/SourceLinkCategoryProfile.cs
@@ -24,5 +24,6 @@ public class SourceLinkCategoryProfile : Profile
             .ForMember(dest => dest.StreetcodeCategoryContents, opt => opt.Ignore())
             .ForPath(dest => dest.Image!.Streetcodes, c => c.Ignore())
             .ForMember(dest => dest.ImageId, opt => opt.MapFrom(dto => dto.ImageId));
+        CreateMap<SourceLinkCategoryCreateDto, SourceLinkCategory>();
     }
 }

--- a/Streetcode/Streetcode.BLL/MediatR/AdditionalContent/Coordinate/Create/CreateCoordinateHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/AdditionalContent/Coordinate/Create/CreateCoordinateHandler.cs
@@ -27,7 +27,7 @@ public class CreateCoordinateHandler : IRequestHandler<CreateCoordinateCommand, 
 
         await _repositoryWrapper.StreetcodeCoordinateRepository.CreateAsync(streetcodeCoordinate);
 
-        var resultIsSuccess = await _repositoryWrapper.SaveChangesAsync() > 0;
+        bool resultIsSuccess = await _repositoryWrapper.SaveChangesAsync() > 0;
         return resultIsSuccess ? Result.Ok(Unit.Value) : Result.Fail(new Error("Failed to create a streetcodeCoordinate"));
     }
 }

--- a/Streetcode/Streetcode.BLL/MediatR/Sources/SourceLinkCategory/Create/CreateSourceLinkCategoryCommand.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Sources/SourceLinkCategory/Create/CreateSourceLinkCategoryCommand.cs
@@ -1,0 +1,9 @@
+using MediatR;
+
+namespace Streetcode.BLL.MediatR.Sources.SourceLinkCategory.Create;
+
+using FluentResults;
+using Dto.Sources;
+
+public record CreateSourceLinkCategoryCommand(SourceLinkCategoryCreateDto SrcLinkCategoryCreateDto)
+    : IRequest<Result<Unit>>;

--- a/Streetcode/Streetcode.BLL/MediatR/Sources/SourceLinkCategory/Create/CreateSourceLinkCategoryCommandValidator.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Sources/SourceLinkCategory/Create/CreateSourceLinkCategoryCommandValidator.cs
@@ -1,0 +1,27 @@
+using Streetcode.DAL.Repositories.Interfaces.Base;
+
+namespace Streetcode.BLL.MediatR.Sources.SourceLinkCategory.Create;
+
+using FluentValidation;
+using Repositories.Interfaces;
+
+public class CreateSourceLinkCategoryCommandValidator: AbstractValidator<CreateSourceLinkCategoryCommand>
+{
+    public CreateSourceLinkCategoryCommandValidator(IRepositoryWrapper repositoryWrapper)
+    {
+        RuleFor(x => x.SrcLinkCategoryCreateDto.Title)
+            .NotEmpty()
+            .WithMessage("Title is required")
+            .MaximumLength(100)
+            .WithMessage("Title can not exceed 100 characters");
+
+        RuleFor(x => x.SrcLinkCategoryCreateDto.ImageId)
+            .Must((imageId, _) =>
+            {
+                return repositoryWrapper.ImageRepository
+                    .GetFirstOrDefaultAsync(image => image.Id == imageId.SrcLinkCategoryCreateDto.ImageId)
+                    .Result != null;
+            })
+            .WithMessage("Image Id doesn't exist");
+    }
+}

--- a/Streetcode/Streetcode.BLL/MediatR/Sources/SourceLinkCategory/Create/CreateSourceLinkCategoryHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Sources/SourceLinkCategory/Create/CreateSourceLinkCategoryHandler.cs
@@ -1,0 +1,48 @@
+using MediatR;
+using Serilog;
+using Streetcode.BLL.Interfaces.Logging;
+
+namespace Streetcode.BLL.MediatR.Sources.SourceLinkCategory.Create;
+
+using AutoMapper;
+using FluentResults;
+using DAL.Repositories.Interfaces.Base;
+using SourceLinkCategory = DAL.Entities.Sources.SourceLinkCategory;
+
+public class CreateSourceLinkCategoryHandler: IRequestHandler<CreateSourceLinkCategoryCommand, Result<Unit>>
+{
+    private readonly IRepositoryWrapper _repositoryWrapper;
+    private readonly IMapper _mapper;
+    private readonly ILoggerService _logger;
+
+    public CreateSourceLinkCategoryHandler(IRepositoryWrapper repositoryWrapper, IMapper mapper, ILoggerService logger)
+    {
+        _repositoryWrapper = repositoryWrapper;
+        _mapper = mapper;
+        _logger = logger;
+    }
+    
+    public async Task<Result<Unit>> Handle(CreateSourceLinkCategoryCommand request, CancellationToken cancellationToken)
+    {
+        SourceLinkCategory sourceLinkCategory = _mapper.Map<SourceLinkCategory>(request.SrcLinkCategoryCreateDto);
+        
+        if (sourceLinkCategory is null)
+        {
+            const string errorMessage = "Cannot convert null to SourceLinkCategory";
+            _logger.LogError(request, errorMessage);
+            return Result.Fail(new Error(errorMessage));
+        }
+
+        await _repositoryWrapper.SourceCategoryRepository.CreateAsync(sourceLinkCategory);
+        bool isResultSuccess = await _repositoryWrapper.SaveChangesAsync() > 0;
+
+        if (!isResultSuccess)
+        {
+            const string errorMessage = "Failed to create SourceLinkCategory";
+            _logger.LogError(request, errorMessage);
+            return Result.Fail(new Error(errorMessage));
+        }
+        
+        return Result.Ok(Unit.Value);
+    }
+}

--- a/Streetcode/Streetcode.WebApi/Controllers/Source/SourcesController.cs
+++ b/Streetcode/Streetcode.WebApi/Controllers/Source/SourcesController.cs
@@ -1,6 +1,8 @@
 using Microsoft.AspNetCore.Mvc;
+using Streetcode.BLL.Dto.Sources;
 using Streetcode.BLL.MediatR.Sources.SourceLink.GetCategoryById;
 using Streetcode.BLL.MediatR.Sources.SourceLink.GetCategoriesByStreetcodeId;
+using Streetcode.BLL.MediatR.Sources.SourceLinkCategory.Create;
 using Streetcode.BLL.MediatR.Sources.SourceLinkCategory.GetAll;
 using Streetcode.BLL.MediatR.Sources.SourceLinkCategory.GetCategoryContentByStreetcodeId;
 
@@ -36,5 +38,11 @@ public class SourcesController : BaseApiController
     public async Task<IActionResult> GetCategoriesByStreetcodeId([FromRoute] int streetcodeId)
     {
         return HandleResult(await Mediator.Send(new GetCategoriesByStreetcodeIdQuery(streetcodeId)));
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Create([FromBody] SourceLinkCategoryCreateDto srcLinkCategoryCreateDto)
+    {
+        return HandleResult(await Mediator.Send(new CreateSourceLinkCategoryCommand(srcLinkCategoryCreateDto)));
     }
 }

--- a/Streetcode/Streetcode.XUnitTest/MediatRTests/Sources/SourceLinkCategory/CreateSourceLinkCategoryHandlerTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatRTests/Sources/SourceLinkCategory/CreateSourceLinkCategoryHandlerTests.cs
@@ -1,0 +1,114 @@
+using Streetcode.BLL.Dto.Sources;
+using Streetcode.BLL.Interfaces.Logging;
+using Streetcode.BLL.MediatR.Sources.SourceLinkCategory.Create;
+using Streetcode.DAL.Repositories.Interfaces.Base;
+
+namespace Streetcode.XUnitTest.MediatRTests.Sources.SourceLinkCategory;
+
+using AutoMapper;
+using Moq;
+using Xunit;
+using FluentAssertions;
+using MediatR;
+using SourceLinkCategory = DAL.Entities.Sources.SourceLinkCategory;
+
+public class CreateSourceLinkCategoryHandlerTests
+{
+    private readonly Mock<IRepositoryWrapper> _repositoryWrapperMock;
+    private readonly Mock<IMapper> _mapperMock;
+    private readonly Mock<ILoggerService> _loggerServiceMock;
+    private readonly CreateSourceLinkCategoryHandler _handler;
+
+    public CreateSourceLinkCategoryHandlerTests()
+    {
+        _repositoryWrapperMock = new Mock<IRepositoryWrapper>();
+        _mapperMock = new Mock<IMapper>();
+        _loggerServiceMock = new Mock<ILoggerService>();
+        _handler = new CreateSourceLinkCategoryHandler(
+            _repositoryWrapperMock.Object, 
+            _mapperMock.Object, 
+            _loggerServiceMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnSuccessResult_WhenSourceLinkIsAdded()
+    {
+        // Assert
+        var sourceLinkCategoryCreateDto = new SourceLinkCategoryCreateDto("Title", 1);
+        var command = new CreateSourceLinkCategoryCommand(sourceLinkCategoryCreateDto);
+        var sourceLinkCategory = new SourceLinkCategory
+        {
+            Title = sourceLinkCategoryCreateDto.Title,
+            ImageId = sourceLinkCategoryCreateDto.ImageId,
+        };
+
+        _mapperMock.Setup(x => x.Map<SourceLinkCategory>(sourceLinkCategoryCreateDto)).Returns(sourceLinkCategory);
+        _repositoryWrapperMock
+            .Setup(x => x.SourceCategoryRepository.CreateAsync(It.IsAny<SourceLinkCategory>()))
+            .ReturnsAsync(sourceLinkCategory);
+        _repositoryWrapperMock.Setup(x => x.SaveChangesAsync()).ReturnsAsync(1);
+        
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().Be(Unit.Value);
+        _repositoryWrapperMock.Verify(
+            x => x.SourceCategoryRepository.CreateAsync(It.IsAny<SourceLinkCategory>()), 
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnFailureResult_WhenDtoNotMapped()
+    {
+        // Arrange
+        SourceLinkCategoryCreateDto sourceLinkCategoryDto = null!;
+        SourceLinkCategory sourceLinkCategory = null!;
+        var command = new CreateSourceLinkCategoryCommand(sourceLinkCategoryDto);
+
+        _mapperMock
+            .Setup(x => x.Map<SourceLinkCategory>(It.IsAny<SourceLinkCategoryCreateDto>()))
+            .Returns(sourceLinkCategory);
+        
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+        
+        // Assert
+        result.IsFailed.Should().BeTrue();
+        _loggerServiceMock.Verify(
+            x => x.LogError(It.IsAny<CreateSourceLinkCategoryCommand>(), "Cannot convert null to SourceLinkCategory"),
+            Times.Once);
+        _repositoryWrapperMock.Verify(
+            x => x.SourceCategoryRepository.CreateAsync(It.IsAny<SourceLinkCategory>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReturnFailureResult_WhenChangesNotSaved()
+    {
+        // Assert
+        var sourceLinkCategoryCreateDto = new SourceLinkCategoryCreateDto("Title", 1);
+        var sourceLinkCategory = new SourceLinkCategory
+        {
+            Title = sourceLinkCategoryCreateDto.Title,
+            ImageId = sourceLinkCategoryCreateDto.ImageId,
+        };
+        var command = new CreateSourceLinkCategoryCommand(sourceLinkCategoryCreateDto);
+
+        _mapperMock.Setup(x => x.Map<SourceLinkCategory>(sourceLinkCategoryCreateDto)).Returns(sourceLinkCategory);
+        _repositoryWrapperMock
+            .Setup(x => x.SourceCategoryRepository.CreateAsync(It.IsAny<SourceLinkCategory>()))
+            .ReturnsAsync(sourceLinkCategory);
+        _repositoryWrapperMock.Setup(x => x.SaveChangesAsync()).ReturnsAsync(0);
+        
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+        
+        // Assert 
+        result.IsFailed.Should().BeTrue();
+        _loggerServiceMock.Verify(
+            x => x.LogError(It.IsAny<CreateSourceLinkCategoryCommand>(), "Failed to create SourceLinkCategory"),
+            Times.Once);
+    }
+}


### PR DESCRIPTION
dev
## Summary of issue

Admin sholud be able to create new source link category.

## Summary of change

To add this functionality next items were implemented:
- `SourceLinkCategoryCreateDto` created;
- configured one-way mapping from `SourceLinkCategoryCreateDto` to `SourceLinkCategory` (entity). Reverse mapping is not needed due to lack of necessity to create a Dto for creation based on allready existing entity;
- implemented command `CreateSourceLinkCategoryCommand` and handler `CreateSourceLinkCategoryHandler`;
- implement validator `CreateSOurceLinkCategoryValidator` that is used by `ValidationPipelineBehavior` to validate `SourceLinkCategoryCreateDto`;
- added corresponding endpoint in SourcesController;
- covered mediator with unit tests;

## CHECK LIST
- [x]  СI passed
- [x]  Сode coverage >=50%
- [x]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [x]  PR meets all conventions

This PR closes issue #102 