### PR TITLE
feat/114/add source category to streetcode implemented

### DIFF
--- a/Streetcode/Streetcode.BLL/Dto/Sources/CategoryContentCreateDto.cs
+++ b/Streetcode/Streetcode.BLL/Dto/Sources/CategoryContentCreateDto.cs
@@ -2,7 +2,6 @@ namespace Streetcode.BLL.Dto.Sources
 {
   public class CategoryContentCreateDto
   {
-    public int? Id { get; set; }
     public int SourceLinkCategoryId { get; set; }
     public string? Text { get; set; }
     public int StreetcodeId { get; set; }

--- a/Streetcode/Streetcode.BLL/MediatR/Sources/StreetcodeCategoryContent/Create/CreateStreetcodeCategoryContentCommand.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Sources/StreetcodeCategoryContent/Create/CreateStreetcodeCategoryContentCommand.cs
@@ -1,0 +1,9 @@
+using MediatR;
+
+namespace Streetcode.BLL.MediatR.Sources.StreetcodeCategoryContent.Create;
+
+using FluentResults;
+using Dto.Sources;
+
+public record CreateStreetcodeCategoryContentCommand(CategoryContentCreateDto CategoryContentCreateDto)
+    : IRequest<Result<Unit>>;

--- a/Streetcode/Streetcode.BLL/MediatR/Sources/StreetcodeCategoryContent/Create/CreateStreetcodeCategoryContentHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Sources/StreetcodeCategoryContent/Create/CreateStreetcodeCategoryContentHandler.cs
@@ -1,0 +1,45 @@
+using MediatR;
+using Streetcode.DAL.Repositories.Interfaces.Base;
+
+namespace Streetcode.BLL.MediatR.Sources.StreetcodeCategoryContent.Create;
+
+using AutoMapper;
+using FluentResults;
+using Microsoft.AspNetCore.Http;
+using Exceptions.CustomExceptions;
+using Interfaces.Logging;
+using StreetcodeCategoryContent = DAL.Entities.Sources.StreetcodeCategoryContent;
+
+public class CreateStreetcodeCategoryContentHandler: IRequestHandler<CreateStreetcodeCategoryContentCommand, Result<Unit>>
+{
+    private readonly IRepositoryWrapper _repositoryWrapper;
+    private readonly IMapper _mapper;
+
+    public CreateStreetcodeCategoryContentHandler(
+        IRepositoryWrapper repositoryWrapper, 
+        IMapper mapper)
+    {
+        _repositoryWrapper = repositoryWrapper;
+        _mapper = mapper;
+    }
+    
+    public async Task<Result<Unit>> Handle(CreateStreetcodeCategoryContentCommand request, CancellationToken token)
+    {
+        var streetcodeCategoryContent = _mapper.Map<StreetcodeCategoryContent>(request.CategoryContentCreateDto);
+        
+        if (streetcodeCategoryContent is null)
+        {
+            throw new CustomException("Cannot convert null to StreetcodeContent", StatusCodes.Status204NoContent);
+        }
+
+        await _repositoryWrapper.StreetcodeCategoryContentRepository.CreateAsync(streetcodeCategoryContent);
+        var isResultSuccessful = await _repositoryWrapper.SaveChangesAsync() > 0;
+
+        if (!isResultSuccessful)
+        {
+            throw new CustomException("Failed to create SourceLinkCategory", StatusCodes.Status400BadRequest);
+        }
+
+        return Result.Ok(Unit.Value);
+    }
+}

--- a/Streetcode/Streetcode.BLL/MediatR/Sources/StreetcodeCategoryContent/Create/CreateStreetcodeCategoryValidator.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Sources/StreetcodeCategoryContent/Create/CreateStreetcodeCategoryValidator.cs
@@ -1,0 +1,36 @@
+using FluentValidation;
+using Streetcode.DAL.Repositories.Interfaces.Base;
+
+namespace Streetcode.BLL.MediatR.Sources.StreetcodeCategoryContent.Create;
+
+public class CreateStreetcodeCategoryValidator: AbstractValidator<CreateStreetcodeCategoryContentCommand>
+{
+    public CreateStreetcodeCategoryValidator(IRepositoryWrapper repositoryWrapper)
+    {
+        RuleFor(x => x.CategoryContentCreateDto.Text)
+            .NotEmpty()
+            .WithMessage("Category content text must not be empty")
+            .MaximumLength(4000)
+            .WithMessage("Category content text must not exceed 4000 symbols");
+
+        RuleFor(x => x.CategoryContentCreateDto.StreetcodeId)
+            .Must((command, _) =>
+            {
+                return repositoryWrapper.StreetcodeRepository
+                    .GetFirstOrDefaultAsync(
+                        streetcode => streetcode.Id == command.CategoryContentCreateDto.StreetcodeId)
+                    .Result != null;
+            })
+            .WithMessage("Streetcode doesn't exist");
+        
+        RuleFor(x => x.CategoryContentCreateDto.SourceLinkCategoryId)
+            .Must((command, _) =>
+            {
+                return repositoryWrapper.SourceCategoryRepository
+                    .GetFirstOrDefaultAsync(
+                        category => category.Id == command.CategoryContentCreateDto.SourceLinkCategoryId)
+                    .Result != null;
+            })
+            .WithMessage("SourceLinkCategory doesn't exist");
+    }
+}

--- a/Streetcode/Streetcode.WebApi/Controllers/Source/SourcesController.cs
+++ b/Streetcode/Streetcode.WebApi/Controllers/Source/SourcesController.cs
@@ -1,9 +1,11 @@
 using Microsoft.AspNetCore.Mvc;
+using Streetcode.BLL.Dto.Sources;
 using Streetcode.BLL.MediatR.Sources.SourceLink.GetCategoryById;
 using Streetcode.BLL.MediatR.Sources.SourceLink.GetCategoriesByStreetcodeId;
 using Streetcode.BLL.MediatR.Sources.SourceLinkCategory.GetAll;
 using Streetcode.BLL.MediatR.Sources.SourceLinkCategory.GetCategoryContentByStreetcodeId;
 using Streetcode.BLL.MediatR.Sources.SourceLinkCategory.Delete;
+using Streetcode.BLL.MediatR.Sources.StreetcodeCategoryContent.Create;
 
 namespace Streetcode.WebApi.Controllers.Source;
 
@@ -43,5 +45,11 @@ public class SourcesController : BaseApiController
     public async Task<IActionResult> DeleteCategoryContent([FromRoute] int streetcodeId, [FromRoute] int categoryId)
     {
         return HandleResult(await Mediator.Send(new DeleteCategoryContentByStreetcodeIdQuery(streetcodeId, categoryId)));
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> CreateCategoryContent([FromBody] CategoryContentCreateDto categoryContentCreateDto)
+    {
+        return HandleResult(await Mediator.Send(new CreateStreetcodeCategoryContentCommand(categoryContentCreateDto)));
     }
 }

--- a/Streetcode/Streetcode.XUnitTest/MediatRTests/Sources/SourceLinkCategory/DeleteCategoryContentByStreetcodeIdHandlerTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatRTests/Sources/SourceLinkCategory/DeleteCategoryContentByStreetcodeIdHandlerTests.cs
@@ -12,9 +12,9 @@ using Streetcode.DAL.Entities.Transactions;
 using Streetcode.DAL.Repositories.Interfaces.Base;
 using System.Linq.Expressions;
 using Xunit;
-
 namespace Streetcode.XUnitTest.MediatRTests.Sources.SourceLinkCategory
 {
+    using StreetcodeCategoryContent = DAL.Entities.Sources.StreetcodeCategoryContent;
     public class DeleteCategoryHandlerTests
     {
         private readonly Mock<IRepositoryWrapper> _repositoryMock;

--- a/Streetcode/Streetcode.XUnitTest/MediatRTests/Sources/StreetcodeCategoryContent/CreateStreetcodeCategoryContentHandlerTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatRTests/Sources/StreetcodeCategoryContent/CreateStreetcodeCategoryContentHandlerTests.cs
@@ -1,0 +1,116 @@
+using FluentAssertions;
+using MediatR;
+using Streetcode.BLL.Dto.Sources;
+using Streetcode.BLL.MediatR.Sources.StreetcodeCategoryContent.Create;
+using Streetcode.DAL.Repositories.Interfaces.Base;
+using Xunit;
+
+namespace Streetcode.XUnitTest.MediatRTests.Sources.StreetcodeCategoryContent;
+
+using AutoMapper;
+using Moq;
+using StreetcodeCategoryContent = DAL.Entities.Sources.StreetcodeCategoryContent;
+
+public class CreateStreetcodeCategoryContentHandlerTests
+{
+    private readonly Mock<IRepositoryWrapper> _repositoryWrapperMock;
+    private readonly Mock<IMapper> _mapperMock;
+    private readonly CreateStreetcodeCategoryContentHandler _handler;
+
+    public CreateStreetcodeCategoryContentHandlerTests()
+    {
+        _repositoryWrapperMock = new Mock<IRepositoryWrapper>();
+        _mapperMock = new Mock<IMapper>();
+        _handler = new CreateStreetcodeCategoryContentHandler(
+            _repositoryWrapperMock.Object, 
+            _mapperMock.Object);
+    }
+    
+    [Fact]
+    public async Task Handle_ShouldReturnSuccessResult_WhenCategoryContentIsAdded()
+    {
+        // Assert
+        var categoryContentCreateDto = new CategoryContentCreateDto
+        {
+            Text = "Test",
+            StreetcodeId = 1,
+            SourceLinkCategoryId = 1,
+        };
+        var categoryContent = new StreetcodeCategoryContent
+        {
+            Text = categoryContentCreateDto.Text,
+            StreetcodeId = categoryContentCreateDto.StreetcodeId,
+            SourceLinkCategoryId = categoryContentCreateDto.SourceLinkCategoryId
+        };
+        var command = new CreateStreetcodeCategoryContentCommand(categoryContentCreateDto);
+
+        _mapperMock.Setup(x => x.Map<StreetcodeCategoryContent>(categoryContentCreateDto)).Returns(categoryContent);
+        _repositoryWrapperMock
+            .Setup(x => x.StreetcodeCategoryContentRepository.CreateAsync(It.IsAny<StreetcodeCategoryContent>()))
+            .ReturnsAsync(categoryContent);
+        _repositoryWrapperMock.Setup(x => x.SaveChangesAsync()).ReturnsAsync(1);
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().Be(Unit.Value);
+        _repositoryWrapperMock.Verify(
+            x => x.StreetcodeCategoryContentRepository.CreateAsync(It.IsAny<StreetcodeCategoryContent>()), 
+            Times.Once);
+    }
+    
+    [Fact]
+    public void Handle_ShouldReturnFailureResult_WhenDtoNotMapped()
+    {
+        // Assert
+        var categoryContentCreateDto = new CategoryContentCreateDto
+        {
+            Text = "Test",
+            StreetcodeId = 1,
+            SourceLinkCategoryId = 1,
+        };
+        StreetcodeCategoryContent categoryContent = null!;
+        var command = new CreateStreetcodeCategoryContentCommand(categoryContentCreateDto);
+
+        _mapperMock.Setup(x => x.Map<StreetcodeCategoryContent>(categoryContentCreateDto)).Returns(categoryContent);
+
+        // Assert
+        Assert.Throws<AggregateException>(() => _handler.Handle(command, CancellationToken.None).Result);
+        _repositoryWrapperMock.Verify(
+            x => x.StreetcodeCategoryContentRepository.CreateAsync(It.IsAny<StreetcodeCategoryContent>()), 
+            Times.Never);
+    }
+    
+    [Fact]
+    public void Handle_ShouldReturnFailureResult_WhenChangesNotSaved()
+    {
+        // Assert
+        var categoryContentCreateDto = new CategoryContentCreateDto
+        {
+            Text = "Test",
+            StreetcodeId = 1,
+            SourceLinkCategoryId = 1,
+        };
+        var categoryContent = new StreetcodeCategoryContent
+        {
+            Text = categoryContentCreateDto.Text,
+            StreetcodeId = categoryContentCreateDto.StreetcodeId,
+            SourceLinkCategoryId = categoryContentCreateDto.SourceLinkCategoryId
+        };
+        var command = new CreateStreetcodeCategoryContentCommand(categoryContentCreateDto);
+
+        _mapperMock.Setup(x => x.Map<StreetcodeCategoryContent>(categoryContentCreateDto)).Returns(categoryContent);
+        _repositoryWrapperMock
+            .Setup(x => x.StreetcodeCategoryContentRepository.CreateAsync(It.IsAny<StreetcodeCategoryContent>()))
+            .ReturnsAsync(categoryContent);
+        _repositoryWrapperMock.Setup(x => x.SaveChangesAsync()).ReturnsAsync(0);
+
+        // Assert
+        Assert.Throws<AggregateException>(() => _handler.Handle(command, CancellationToken.None).Result);
+        _repositoryWrapperMock.Verify(
+            x => x.StreetcodeCategoryContentRepository.CreateAsync(It.IsAny<StreetcodeCategoryContent>()), 
+            Times.Once);
+    }
+}


### PR DESCRIPTION
dev
## Summary of issue

Admin sholud be able to add source link category to streetcode.

## Summary of change

To add this functionality next items were implemented:
- `CategoryContentCreateDto` modified, remove unnecessary Id property;
- implemented command `CreateStreetcodeCategoryContentCommand` and handler `CreateStreetcodeCategoryContentHandler`;
- implement validator `CreateStreetcodeCategoryContentValidator` that is used by `ValidationPipelineBehavior` to validate `CategoryContentCreateDto`;
- added corresponding endpoint in SourcesController;
- covered mediator with unit tests;

Also added extra using for type `StreetcodeCategoryContent` in `DeleteCategoryHandlerTests` file because for some reason compiler argued on absence of using directive for this type.


## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=50%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  PR meets all conventions

This PR closes issue #114 
