### PR TITLE
fix/156/ move transactions tests into right directory and adjust…

### DIFF
--- a/Streetcode/Streetcode.XUnitTest/MediatRTests/Transactions/TransactionLink/GetAllTransactLinksHandlerTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatRTests/Transactions/TransactionLink/GetAllTransactLinksHandlerTests.cs
@@ -1,4 +1,5 @@
-﻿using AutoMapper;
+﻿using System.Linq.Expressions;
+using AutoMapper;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore.Query;
 using Moq;
@@ -6,12 +7,10 @@ using Streetcode.BLL.Dto.Transactions;
 using Streetcode.BLL.Interfaces.Logging;
 using Streetcode.BLL.MediatR.Transactions.TransactionLink.GetAll;
 using Streetcode.DAL.Repositories.Interfaces.Base;
-using System.Linq.Expressions;
 using Xunit;
-
 using TransactLink = Streetcode.DAL.Entities.Transactions.TransactionLink;
 
-namespace Streetcode.XUnitTest.MediatRTests.Streetcode.Transactions.TransactionLink
+namespace Streetcode.XUnitTest.MediatRTests.Transactions.TransactionLink
 {
     public class GetAllTransactLinksHandlerTests
     {

--- a/Streetcode/Streetcode.XUnitTest/MediatRTests/Transactions/TransactionLink/GetAllTransactLinksHandlerTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatRTests/Transactions/TransactionLink/GetAllTransactLinksHandlerTests.cs
@@ -61,9 +61,8 @@ namespace Streetcode.XUnitTest.MediatRTests.Transactions.TransactionLink
             // Arrange
             _mockRepository.Setup(repo => repo.TransactLinksRepository.GetAllAsync(
                 It.IsAny<Expression<Func<TransactLink, bool>>>(),
-                It.IsAny<Func<IQueryable<TransactLink>, IIncludableQueryable<TransactLink, object>>>()
-                ))
-            .ReturnsAsync((IEnumerable<TransactLink>) null);
+                It.IsAny<Func<IQueryable<TransactLink>, IIncludableQueryable<TransactLink, object>>>()))
+            .ReturnsAsync((IEnumerable<TransactLink>) null!);
 
             // Act
             var result = await _handler.Handle(new GetAllTransactLinksQuery(), CancellationToken.None);

--- a/Streetcode/Streetcode.XUnitTest/MediatRTests/Transactions/TransactionLink/GetTransactByStreetcodeIdHandlerTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatRTests/Transactions/TransactionLink/GetTransactByStreetcodeIdHandlerTests.cs
@@ -58,27 +58,26 @@ namespace Streetcode.XUnitTest.MediatRTests.Transactions.TransactionLink
         [Fact]
         public async Task Handle_ReturnFailResult_WhenTransactLinkIsNull()
         {
-            var streetCodeId = 1;
-            var query = new GetTransactLinkByStreetcodeIdQuery(streetCodeId);
+            const int StreetcodeId = 1;
+            var query = new GetTransactLinkByStreetcodeIdQuery(StreetcodeId);
 
             // Arrange
             _mockRepository.Setup(repo => repo.TransactLinksRepository.GetFirstOrDefaultAsync(
                 It.IsAny<Expression<Func<TransactLink, bool>>>(), null))
-            .ReturnsAsync((TransactLink)null);
+            .ReturnsAsync((TransactLink)null!);
 
             _mockRepository.Setup(repo => repo.StreetcodeRepository.GetFirstOrDefaultAsync(
                 It.IsAny<Expression<Func<StreetcodeContent, bool>>>(), null))
-            .ReturnsAsync((StreetcodeContent)null);
+            .ReturnsAsync((StreetcodeContent)null!);
 
-            int id = It.IsAny<int>();
 
             // Act
             var result = await _handler.Handle(query, CancellationToken.None);
 
             // Assert
             result.IsSuccess.Should().BeFalse();
-            result.Errors.Should().Contain(error => error.Message == $"Cannot find a transaction link by a streetcode id: {streetCodeId}, because such streetcode doesn`t exist");
-            _mockLogger.Verify(l => l.LogError(It.IsAny<object>(), $"Cannot find a transaction link by a streetcode id: {streetCodeId}, because such streetcode doesn`t exist"), Times.Once);
+            result.Errors.Should().Contain(error => error.Message == $"Cannot find a transaction link by a streetcode id: {StreetcodeId}, because such streetcode doesn`t exist");
+            _mockLogger.Verify(l => l.LogError(It.IsAny<object>(), $"Cannot find a transaction link by a streetcode id: {StreetcodeId}, because such streetcode doesn`t exist"), Times.Once);
         }
     }
 }

--- a/Streetcode/Streetcode.XUnitTest/MediatRTests/Transactions/TransactionLink/GetTransactByStreetcodeIdHandlerTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatRTests/Transactions/TransactionLink/GetTransactByStreetcodeIdHandlerTests.cs
@@ -1,41 +1,40 @@
-﻿using AutoMapper;
+﻿using System.Linq.Expressions;
+using AutoMapper;
 using FluentAssertions;
-using Microsoft.EntityFrameworkCore.Query;
 using Moq;
 using Streetcode.BLL.Dto.Transactions;
 using Streetcode.BLL.Interfaces.Logging;
-using Streetcode.BLL.MediatR.Transactions.TransactionLink.GetById;
 using Streetcode.BLL.MediatR.Transactions.TransactionLink.GetByStreetcodeId;
+using Streetcode.DAL.Entities.Streetcode;
 using Streetcode.DAL.Repositories.Interfaces.Base;
-using System.Linq.Expressions;
 using Xunit;
 using TransactLink = Streetcode.DAL.Entities.Transactions.TransactionLink;
 
-namespace Streetcode.XUnitTest.MediatRTests.Streetcode.Transactions.TransactionLink
+namespace Streetcode.XUnitTest.MediatRTests.Transactions.TransactionLink
 {
-    public class GetTransactLinkByIdHandlerTests
+    public class GetTransactByStreetcodeIdHandlerTests
     {
         private readonly Mock<IRepositoryWrapper> _mockRepository;
         private readonly Mock<IMapper> _mockMapper;
         private readonly Mock<ILoggerService> _mockLogger;
-        private readonly GetTransactLinkByIdHandler _handler;
+        private readonly GetTransactLinkByStreetcodeIdHandler _handler;
 
-        public GetTransactLinkByIdHandlerTests()
+        public GetTransactByStreetcodeIdHandlerTests()
         {
             _mockRepository = new Mock<IRepositoryWrapper>();
             _mockMapper = new Mock<IMapper>();
             _mockLogger = new Mock<ILoggerService>();
-            _handler = new GetTransactLinkByIdHandler(_mockRepository.Object, _mockMapper.Object, _mockLogger.Object);
+            _handler = new GetTransactLinkByStreetcodeIdHandler(_mockRepository.Object, _mockMapper.Object, _mockLogger.Object);
         }
 
         [Fact]
         public async Task Handle_ReturnOkResult_WhenTransactLinkExist()
         {
             // Arrange
-            var id = 1;
-            var transactionLink = new TransactLink { Id = id, StreetcodeId = 1 };
+            var streetCodeId = 1;
+            var transactionLink = new TransactLink { Id = 1, StreetcodeId = streetCodeId };
             var transactionDto = new TransactLinkDto { Id = transactionLink.Id, StreetcodeId = transactionLink.StreetcodeId };
-            var query = new GetTransactLinkByIdQuery(id);
+            var query = new GetTransactLinkByStreetcodeIdQuery(streetCodeId);
 
             _mockRepository.Setup(repo => repo.TransactLinksRepository.GetFirstOrDefaultAsync(
                 It.Is<Expression<Func<TransactLink, bool>>>(exp => exp.Compile().Invoke(transactionLink)), null))
@@ -52,28 +51,34 @@ namespace Streetcode.XUnitTest.MediatRTests.Streetcode.Transactions.TransactionL
 
             _mockRepository.Verify(repo => repo.TransactLinksRepository.GetFirstOrDefaultAsync(
                     It.Is<Expression<Func<TransactLink, bool>>>(
-                         exp => exp.Compile().Invoke(new TransactLink { Id = query.Id })),
+                         exp => exp.Compile().Invoke(new TransactLink { StreetcodeId = query.StreetcodeId })),
             null), Times.Once);
         }
 
+        [Fact]
         public async Task Handle_ReturnFailResult_WhenTransactLinkIsNull()
         {
+            var streetCodeId = 1;
+            var query = new GetTransactLinkByStreetcodeIdQuery(streetCodeId);
+
             // Arrange
             _mockRepository.Setup(repo => repo.TransactLinksRepository.GetFirstOrDefaultAsync(
-                It.IsAny<Expression<Func<TransactLink, bool>>>(),
-                It.IsAny<Func<IQueryable<TransactLink>, IIncludableQueryable<TransactLink, object>>>()
-                ))
+                It.IsAny<Expression<Func<TransactLink, bool>>>(), null))
             .ReturnsAsync((TransactLink)null);
+
+            _mockRepository.Setup(repo => repo.StreetcodeRepository.GetFirstOrDefaultAsync(
+                It.IsAny<Expression<Func<StreetcodeContent, bool>>>(), null))
+            .ReturnsAsync((StreetcodeContent)null);
 
             int id = It.IsAny<int>();
 
             // Act
-            var result = await _handler.Handle(new GetTransactLinkByIdQuery(id), CancellationToken.None);
+            var result = await _handler.Handle(query, CancellationToken.None);
 
             // Assert
             result.IsSuccess.Should().BeFalse();
-            result.Errors.Should().Contain(error => error.Message == $"Cannot find any transaction link with corresponding id: {id}");
-            _mockLogger.Verify(l => l.LogError(It.IsAny<object>(), $"Cannot find any transaction link with corresponding id: {id}"), Times.Once);
+            result.Errors.Should().Contain(error => error.Message == $"Cannot find a transaction link by a streetcode id: {streetCodeId}, because such streetcode doesn`t exist");
+            _mockLogger.Verify(l => l.LogError(It.IsAny<object>(), $"Cannot find a transaction link by a streetcode id: {streetCodeId}, because such streetcode doesn`t exist"), Times.Once);
         }
     }
 }

--- a/Streetcode/Streetcode.XUnitTest/MediatRTests/Transactions/TransactionLink/GetTransactLinkByIdHandlerTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatRTests/Transactions/TransactionLink/GetTransactLinkByIdHandlerTests.cs
@@ -55,6 +55,7 @@ namespace Streetcode.XUnitTest.MediatRTests.Transactions.TransactionLink
             null), Times.Once);
         }
 
+        [Fact]
         public async Task Handle_ReturnFailResult_WhenTransactLinkIsNull()
         {
             // Arrange
@@ -62,7 +63,7 @@ namespace Streetcode.XUnitTest.MediatRTests.Transactions.TransactionLink
                 It.IsAny<Expression<Func<TransactLink, bool>>>(),
                 It.IsAny<Func<IQueryable<TransactLink>, IIncludableQueryable<TransactLink, object>>>()
                 ))
-            .ReturnsAsync((TransactLink)null);
+            .ReturnsAsync((TransactLink)null!);
 
             int id = It.IsAny<int>();
 

--- a/Streetcode/Streetcode.XUnitTest/MediatRTests/Transactions/TransactionLink/GetTransactLinkByIdHandlerTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatRTests/Transactions/TransactionLink/GetTransactLinkByIdHandlerTests.cs
@@ -1,45 +1,40 @@
-﻿using AutoMapper;
+﻿using System.Linq.Expressions;
+using AutoMapper;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore.Query;
 using Moq;
 using Streetcode.BLL.Dto.Transactions;
 using Streetcode.BLL.Interfaces.Logging;
 using Streetcode.BLL.MediatR.Transactions.TransactionLink.GetById;
-using Streetcode.BLL.MediatR.Transactions.TransactionLink.GetByStreetcodeId;
-using Streetcode.DAL.Entities.Streetcode;
-using Streetcode.DAL.Entities.Transactions;
 using Streetcode.DAL.Repositories.Interfaces.Base;
-using Streetcode.DAL.Repositories.Realizations.Transactions;
-using System.Linq.Expressions;
 using Xunit;
-using static Microsoft.EntityFrameworkCore.DbLoggerCategory;
 using TransactLink = Streetcode.DAL.Entities.Transactions.TransactionLink;
 
-namespace Streetcode.XUnitTest.MediatRTests.Streetcode.Transactions.TransactionLink
+namespace Streetcode.XUnitTest.MediatRTests.Transactions.TransactionLink
 {
-    public class GetTransactByStreetcodeIdHandlerTests
+    public class GetTransactLinkByIdHandlerTests
     {
         private readonly Mock<IRepositoryWrapper> _mockRepository;
         private readonly Mock<IMapper> _mockMapper;
         private readonly Mock<ILoggerService> _mockLogger;
-        private readonly GetTransactLinkByStreetcodeIdHandler _handler;
+        private readonly GetTransactLinkByIdHandler _handler;
 
-        public GetTransactByStreetcodeIdHandlerTests()
+        public GetTransactLinkByIdHandlerTests()
         {
             _mockRepository = new Mock<IRepositoryWrapper>();
             _mockMapper = new Mock<IMapper>();
             _mockLogger = new Mock<ILoggerService>();
-            _handler = new GetTransactLinkByStreetcodeIdHandler(_mockRepository.Object, _mockMapper.Object, _mockLogger.Object);
+            _handler = new GetTransactLinkByIdHandler(_mockRepository.Object, _mockMapper.Object, _mockLogger.Object);
         }
 
         [Fact]
         public async Task Handle_ReturnOkResult_WhenTransactLinkExist()
         {
             // Arrange
-            var streetCodeId = 1;
-            var transactionLink = new TransactLink { Id = 1, StreetcodeId = streetCodeId };
+            var id = 1;
+            var transactionLink = new TransactLink { Id = id, StreetcodeId = 1 };
             var transactionDto = new TransactLinkDto { Id = transactionLink.Id, StreetcodeId = transactionLink.StreetcodeId };
-            var query = new GetTransactLinkByStreetcodeIdQuery(streetCodeId);
+            var query = new GetTransactLinkByIdQuery(id);
 
             _mockRepository.Setup(repo => repo.TransactLinksRepository.GetFirstOrDefaultAsync(
                 It.Is<Expression<Func<TransactLink, bool>>>(exp => exp.Compile().Invoke(transactionLink)), null))
@@ -56,34 +51,28 @@ namespace Streetcode.XUnitTest.MediatRTests.Streetcode.Transactions.TransactionL
 
             _mockRepository.Verify(repo => repo.TransactLinksRepository.GetFirstOrDefaultAsync(
                     It.Is<Expression<Func<TransactLink, bool>>>(
-                         exp => exp.Compile().Invoke(new TransactLink { StreetcodeId = query.StreetcodeId })),
+                         exp => exp.Compile().Invoke(new TransactLink { Id = query.Id })),
             null), Times.Once);
         }
 
-        [Fact]
         public async Task Handle_ReturnFailResult_WhenTransactLinkIsNull()
         {
-            var streetCodeId = 1;
-            var query = new GetTransactLinkByStreetcodeIdQuery(streetCodeId);
-
             // Arrange
             _mockRepository.Setup(repo => repo.TransactLinksRepository.GetFirstOrDefaultAsync(
-                It.IsAny<Expression<Func<TransactLink, bool>>>(), null))
+                It.IsAny<Expression<Func<TransactLink, bool>>>(),
+                It.IsAny<Func<IQueryable<TransactLink>, IIncludableQueryable<TransactLink, object>>>()
+                ))
             .ReturnsAsync((TransactLink)null);
-
-            _mockRepository.Setup(repo => repo.StreetcodeRepository.GetFirstOrDefaultAsync(
-                It.IsAny<Expression<Func<StreetcodeContent, bool>>>(), null))
-            .ReturnsAsync((StreetcodeContent)null);
 
             int id = It.IsAny<int>();
 
             // Act
-            var result = await _handler.Handle(query, CancellationToken.None);
+            var result = await _handler.Handle(new GetTransactLinkByIdQuery(id), CancellationToken.None);
 
             // Assert
             result.IsSuccess.Should().BeFalse();
-            result.Errors.Should().Contain(error => error.Message == $"Cannot find a transaction link by a streetcode id: {streetCodeId}, because such streetcode doesn`t exist");
-            _mockLogger.Verify(l => l.LogError(It.IsAny<object>(), $"Cannot find a transaction link by a streetcode id: {streetCodeId}, because such streetcode doesn`t exist"), Times.Once);
+            result.Errors.Should().Contain(error => error.Message == $"Cannot find any transaction link with corresponding id: {id}");
+            _mockLogger.Verify(l => l.LogError(It.IsAny<object>(), $"Cannot find any transaction link with corresponding id: {id}"), Times.Once);
         }
     }
 }


### PR DESCRIPTION
dev

## Summary of issue
Transactions unit tests were palced in wrong directory/

## Summary of change

- Moved Transactions tests into `Streetcode.XUnitTest.MediatRTests`;
- Adjust namespaces
- Removes unnecessary usings


## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=50%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  PR meets all conventions
