### PR TITLE
Feat/165/add related term

### DIFF
--- a/Streetcode/Streetcode.BLL/Dto/Streetcode/TextContent/Term/RelatedTermCreateDto.cs
+++ b/Streetcode/Streetcode.BLL/Dto/Streetcode/TextContent/Term/RelatedTermCreateDto.cs
@@ -1,0 +1,3 @@
+namespace Streetcode.BLL.Dto.Streetcode.TextContent.Term;
+
+public record RelatedTermCreateDto(string Word, int TermId);

--- a/Streetcode/Streetcode.BLL/Dto/Streetcode/TextContent/Term/RelatedTermFullDto.cs
+++ b/Streetcode/Streetcode.BLL/Dto/Streetcode/TextContent/Term/RelatedTermFullDto.cs
@@ -1,0 +1,3 @@
+namespace Streetcode.BLL.Dto.Streetcode.TextContent.Term;
+
+public record RelatedTermFullDto(int Id, string Word, TermDto TermDto);

--- a/Streetcode/Streetcode.BLL/Mapping/Streetcode/TextContent/RelatedTermProfile.cs
+++ b/Streetcode/Streetcode.BLL/Mapping/Streetcode/TextContent/RelatedTermProfile.cs
@@ -10,7 +10,11 @@ public class RelatedTermProfile : Profile
     public RelatedTermProfile()
     {
         CreateMap<RelatedTerm, RelatedTermDto>().ReverseMap();
-        CreateMap<RelatedTermCreateDto, RelatedTerm>();
+        CreateMap<RelatedTermCreateDto, RelatedTerm>()
+            .ForMember(entity => entity.Word, opt => opt.MapFrom(src => src.Word))
+            .ForMember(entity => entity.TermId, opt => opt.MapFrom(src => src.TermId))
+            .ForMember(entity => entity.Term, opt => opt.MapFrom<Term>(_ => null!))
+            .ForMember(entity => entity.Id, opt => opt.MapFrom<int>(_ => default));;
         CreateMap<RelatedTerm, RelatedTermFullDto>()
             .ForCtorParam("Id", opt => opt.MapFrom(src => src.Id))
             .ForCtorParam("Word", opt => opt.MapFrom(src => src.Word))

--- a/Streetcode/Streetcode.BLL/Mapping/Streetcode/TextContent/RelatedTermProfile.cs
+++ b/Streetcode/Streetcode.BLL/Mapping/Streetcode/TextContent/RelatedTermProfile.cs
@@ -10,5 +10,18 @@ public class RelatedTermProfile : Profile
     public RelatedTermProfile()
     {
         CreateMap<RelatedTerm, RelatedTermDto>().ReverseMap();
-     }
+        CreateMap<RelatedTermCreateDto, RelatedTerm>();
+        // CreateMap<RelatedTerm, RelatedTermFullDto>()
+        //     .ForPath(dto => dto.Id, config => config.MapFrom(entity => entity.Id))
+        //     .ForPath(dto => dto.Word, config => config.MapFrom(entity => entity.Word))
+        //     .ForPath(dto => dto.TermDto, config => config.MapFrom(entity => entity.Term));
+        // CreateMap<RelatedTerm, RelatedTermFullDto>()
+        //     .ForMember(dto => dto.Id, config => config.MapFrom(entity => entity.Id))
+        //     .ForMember(dto => dto.Word, config => config.MapFrom(entity => entity.Word))
+        //     .ForMember(dto => dto.TermDto, config => config.MapFrom(entity => entity.Term));
+        CreateMap<RelatedTerm, RelatedTermFullDto>()
+            .ForCtorParam("Id", opt => opt.MapFrom(src => src.Id))
+            .ForCtorParam("Word", opt => opt.MapFrom(src => src.Word))
+            .ForCtorParam("TermDto", opt => opt.MapFrom(src => src.Term));
+    }
 }

--- a/Streetcode/Streetcode.BLL/Mapping/Streetcode/TextContent/RelatedTermProfile.cs
+++ b/Streetcode/Streetcode.BLL/Mapping/Streetcode/TextContent/RelatedTermProfile.cs
@@ -11,14 +11,6 @@ public class RelatedTermProfile : Profile
     {
         CreateMap<RelatedTerm, RelatedTermDto>().ReverseMap();
         CreateMap<RelatedTermCreateDto, RelatedTerm>();
-        // CreateMap<RelatedTerm, RelatedTermFullDto>()
-        //     .ForPath(dto => dto.Id, config => config.MapFrom(entity => entity.Id))
-        //     .ForPath(dto => dto.Word, config => config.MapFrom(entity => entity.Word))
-        //     .ForPath(dto => dto.TermDto, config => config.MapFrom(entity => entity.Term));
-        // CreateMap<RelatedTerm, RelatedTermFullDto>()
-        //     .ForMember(dto => dto.Id, config => config.MapFrom(entity => entity.Id))
-        //     .ForMember(dto => dto.Word, config => config.MapFrom(entity => entity.Word))
-        //     .ForMember(dto => dto.TermDto, config => config.MapFrom(entity => entity.Term));
         CreateMap<RelatedTerm, RelatedTermFullDto>()
             .ForCtorParam("Id", opt => opt.MapFrom(src => src.Id))
             .ForCtorParam("Word", opt => opt.MapFrom(src => src.Word))

--- a/Streetcode/Streetcode.BLL/Mapping/Streetcode/TextContent/RelatedTermProfile.cs
+++ b/Streetcode/Streetcode.BLL/Mapping/Streetcode/TextContent/RelatedTermProfile.cs
@@ -1,5 +1,4 @@
 using AutoMapper;
-using Streetcode.BLL.Dto.Streetcode.TextContent;
 using Streetcode.BLL.Dto.Streetcode.TextContent.Term;
 using Streetcode.DAL.Entities.Streetcode.TextContent;
 
@@ -14,7 +13,12 @@ public class RelatedTermProfile : Profile
             .ForMember(entity => entity.Word, opt => opt.MapFrom(src => src.Word))
             .ForMember(entity => entity.TermId, opt => opt.MapFrom(src => src.TermId))
             .ForMember(entity => entity.Term, opt => opt.MapFrom<Term>(_ => null!))
-            .ForMember(entity => entity.Id, opt => opt.MapFrom<int>(_ => default));;
+            .ForMember(entity => entity.Id, opt => opt.MapFrom<int>(_ => default));
+        CreateMap<RelatedTermFullDto, RelatedTerm>()
+            .ForMember(entity => entity.Id, opt => opt.MapFrom(src => src.Id))
+            .ForMember(entity => entity.Word, opt => opt.MapFrom(src => src.Word))
+            .ForMember(entity => entity.Term, opt => opt.MapFrom(src => src.TermDto))
+            .ForMember(entity => entity.TermId, opt => opt.MapFrom(src => src.TermDto.Id));
         CreateMap<RelatedTerm, RelatedTermFullDto>()
             .ForCtorParam("Id", opt => opt.MapFrom(src => src.Id))
             .ForCtorParam("Word", opt => opt.MapFrom(src => src.Word))

--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/RelatedTerm/Create/CreateRelatedTermCommand.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/RelatedTerm/Create/CreateRelatedTermCommand.cs
@@ -1,11 +1,7 @@
 ﻿using FluentResults;
 using MediatR;
-using Streetcode.BLL.Dto.Streetcode.TextContent;
 using Streetcode.BLL.Dto.Streetcode.TextContent.Term;
 
-namespace Streetcode.BLL.MediatR.Streetcode.RelatedTerm.Create
-{
-    public record CreateRelatedTermCommand(RelatedTermDto RelatedTerm): IRequest<Result<RelatedTermDto>>
-    {
-    }
-}
+namespace Streetcode.BLL.MediatR.Streetcode.RelatedTerm.Create;
+
+public record CreateRelatedTermCommand(RelatedTermCreateDto RelatedTerm) : IRequest<Result<RelatedTermFullDto>>;

--- a/Streetcode/Streetcode.DAL/Entities/Streetcode/TextContent/RelatedTerm.cs
+++ b/Streetcode/Streetcode.DAL/Entities/Streetcode/TextContent/RelatedTerm.cs
@@ -13,8 +13,10 @@ namespace Streetcode.DAL.Entities.Streetcode.TextContent
         [Required]
         [MaxLength(50)]
         public string? Word { get; set; }
+        
         [Required]
         public int TermId { get; set; }
-        public Term? Term { get; set; }
+
+        public Term Term { get; set; } = null!;
     }
 }

--- a/Streetcode/Streetcode.WebApi/Controllers/Streetcode/TextContent/RelatedTermController.cs
+++ b/Streetcode/Streetcode.WebApi/Controllers/Streetcode/TextContent/RelatedTermController.cs
@@ -17,7 +17,7 @@ namespace Streetcode.WebApi.Controllers.Streetcode.TextContent
         }
 
         [HttpPost]
-        public async Task<IActionResult> Create([FromBody] RelatedTermDto relatedTerm)
+        public async Task<IActionResult> Create([FromBody] RelatedTermCreateDto relatedTerm)
         {
             return HandleResult(await Mediator.Send(new CreateRelatedTermCommand(relatedTerm)));
         }

--- a/Streetcode/Streetcode.XUnitTest/MappingTests/Streetcode/TextContent/RelatedTermProfileTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/MappingTests/Streetcode/TextContent/RelatedTermProfileTests.cs
@@ -1,6 +1,7 @@
 using AutoMapper;
 using FluentAssertions;
 using Streetcode.BLL.Dto.Streetcode.TextContent.Term;
+using Streetcode.BLL.Mapping.Streetcode.TextContent;
 using Streetcode.DAL.Entities.Streetcode.TextContent;
 using Xunit;
 
@@ -9,41 +10,24 @@ namespace Streetcode.XUnitTest.MappingTests.Streetcode.TextContent;
 public class RelatedTermProfileTests
 {
     private readonly IMapper _mapper;
+    private readonly MapperConfiguration _config;
 
     public RelatedTermProfileTests()
     {
-        var config = GetMapperConfiguration();
+        _config = new MapperConfiguration(cfg =>
+        {
+            cfg.AddProfile<RelatedTermProfile>();
+            cfg.AddProfile<TermProfile>();
+        });
 
-        _mapper = config.CreateMapper();
+        _mapper = _config.CreateMapper();
     }
 
     [Fact]
     public void MappingConfiguration_IsValid()
     {
-        var config = GetMapperConfiguration();
-
-        config.AssertConfigurationIsValid();
+        _config.AssertConfigurationIsValid();
     }
-    
-    private static MapperConfiguration GetMapperConfiguration() => new (cfg =>
-    {
-        cfg.CreateMap<Term, TermDto>().ReverseMap();
-        cfg.CreateMap<RelatedTerm, RelatedTermDto>().ReverseMap();
-        cfg.CreateMap<RelatedTermCreateDto, RelatedTerm>()
-            .ForMember(entity => entity.Word, opt => opt.MapFrom(src => src.Word))
-            .ForMember(entity => entity.TermId, opt => opt.MapFrom(src => src.TermId))
-            .ForMember(entity => entity.Term, opt => opt.MapFrom<Term>(_ => null!))
-            .ForMember(entity => entity.Id, opt => opt.MapFrom<int>(_ => default));
-        cfg.CreateMap<RelatedTerm, RelatedTermFullDto>()
-            .ForCtorParam("Id", opt => opt.MapFrom(src => src.Id))
-            .ForCtorParam("Word", opt => opt.MapFrom(src => src.Word))
-            .ForCtorParam("TermDto", opt => opt.MapFrom(src => src.Term));
-        cfg.CreateMap<RelatedTermFullDto, RelatedTerm>()
-            .ForMember(entity => entity.Id, opt => opt.MapFrom(src => src.Id))
-            .ForMember(entity => entity.Word, opt => opt.MapFrom(src => src.Word))
-            .ForMember(entity => entity.Term, opt => opt.MapFrom(src => src.TermDto))
-            .ForMember(entity => entity.TermId, opt => opt.MapFrom(src => src.TermDto.Id));
-    });
     
     [Fact]
     public void RelatedTerm_ShouldMapTo_RelatedTermDto()

--- a/Streetcode/Streetcode.XUnitTest/MappingTests/Streetcode/TextContent/RelatedTermProfileTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/MappingTests/Streetcode/TextContent/RelatedTermProfileTests.cs
@@ -1,0 +1,97 @@
+using AutoMapper;
+using FluentAssertions;
+using Streetcode.BLL.Dto.Streetcode.TextContent.Term;
+using Streetcode.DAL.Entities.Streetcode.TextContent;
+using Xunit;
+
+namespace Streetcode.XUnitTest.MappingTests.Streetcode.TextContent;
+
+public class RelatedTermProfileTests
+{
+    private readonly IMapper _mapper;
+
+    public RelatedTermProfileTests()
+    {
+        var config = GetMapperConfiguration();
+
+        _mapper = config.CreateMapper();
+    }
+
+    [Fact]
+    public void MappingConfiguration_IsValid()
+    {
+        var config = GetMapperConfiguration();
+
+        config.AssertConfigurationIsValid();
+    }
+    
+    private static MapperConfiguration GetMapperConfiguration() => new (cfg =>
+    {
+        cfg.CreateMap<Term, TermDto>().ReverseMap();
+        cfg.CreateMap<RelatedTerm, RelatedTermDto>().ReverseMap();
+        cfg.CreateMap<RelatedTermCreateDto, RelatedTerm>()
+            .ForMember(entity => entity.Word, opt => opt.MapFrom(src => src.Word))
+            .ForMember(entity => entity.TermId, opt => opt.MapFrom(src => src.TermId))
+            .ForMember(entity => entity.Term, opt => opt.MapFrom<Term>(_ => null!))
+            .ForMember(entity => entity.Id, opt => opt.MapFrom<int>(_ => default));
+        cfg.CreateMap<RelatedTerm, RelatedTermFullDto>()
+            .ForCtorParam("Id", opt => opt.MapFrom(src => src.Id))
+            .ForCtorParam("Word", opt => opt.MapFrom(src => src.Word))
+            .ForCtorParam("TermDto", opt => opt.MapFrom(src => src.Term));
+    });
+    
+    [Fact]
+    public void RelatedTerm_ShouldMapTo_RelatedTermDto()
+    {
+        // Arrange
+        var relatedTerm = new RelatedTerm
+        {
+            Id = 1,
+            Word = "SampleWord",
+            TermId = 2
+        };
+
+        // Act
+        var relatedTermDto = _mapper.Map<RelatedTermDto>(relatedTerm);
+
+        // Assert
+        Assert.Equal(relatedTerm.Id, relatedTermDto.Id);
+        Assert.Equal(relatedTerm.Word, relatedTermDto.Word);
+        Assert.Equal(relatedTerm.TermId, relatedTermDto.TermId);
+    }
+
+    [Fact]
+    public void RelatedTermCreateDto_ShouldMapTo_RelatedTerm()
+    {
+        // Arrange
+        var createDto = new RelatedTermCreateDto("word", 1);
+
+        // Act
+        var relatedTerm = _mapper.Map<RelatedTerm>(createDto);
+
+        // Assert
+        Assert.Equal(createDto.Word, relatedTerm.Word);
+        Assert.Equal(createDto.TermId, relatedTerm.TermId);
+    }
+
+    [Fact]
+    public void Should_Map_RelatedTerm_To_RelatedTermFullDto()
+    {
+        // Arrange
+        var relatedTerm = new RelatedTerm
+        {
+            Id = 1,
+            Word = "SampleWord",
+            Term = new Term { Id = 2, Title = "SampleTerm", Description = "Description"}
+        };
+
+        // Act
+        var relatedTermFullDto = _mapper.Map<RelatedTermFullDto>(relatedTerm);
+
+        // Assert
+        relatedTermFullDto.Id.Should().Be(1);
+        relatedTermFullDto.Word.Should().Be("SampleWord");
+        relatedTermFullDto.TermDto.Id.Should().Be(2);
+        relatedTermFullDto.TermDto.Title.Should().Be("SampleTerm");
+    }
+}

--- a/Streetcode/Streetcode.XUnitTest/MappingTests/Streetcode/TextContent/RelatedTermProfileTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/MappingTests/Streetcode/TextContent/RelatedTermProfileTests.cs
@@ -38,6 +38,11 @@ public class RelatedTermProfileTests
             .ForCtorParam("Id", opt => opt.MapFrom(src => src.Id))
             .ForCtorParam("Word", opt => opt.MapFrom(src => src.Word))
             .ForCtorParam("TermDto", opt => opt.MapFrom(src => src.Term));
+        cfg.CreateMap<RelatedTermFullDto, RelatedTerm>()
+            .ForMember(entity => entity.Id, opt => opt.MapFrom(src => src.Id))
+            .ForMember(entity => entity.Word, opt => opt.MapFrom(src => src.Word))
+            .ForMember(entity => entity.Term, opt => opt.MapFrom(src => src.TermDto))
+            .ForMember(entity => entity.TermId, opt => opt.MapFrom(src => src.TermDto.Id));
     });
     
     [Fact]

--- a/Streetcode/Streetcode.XUnitTest/MediatRTests/Streetcode/RelatedTerm/CreateRelatedTermHandlerTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatRTests/Streetcode/RelatedTerm/CreateRelatedTermHandlerTests.cs
@@ -1,7 +1,6 @@
 ﻿using AutoMapper;
 using FluentAssertions;
 using Moq;
-using Streetcode.BLL.Dto.Streetcode.TextContent;
 using Streetcode.BLL.Interfaces.Logging;
 using Streetcode.BLL.MediatR.Streetcode.RelatedTerm.Create;
 using Streetcode.DAL.Repositories.Interfaces.Base;
@@ -17,22 +16,20 @@ namespace Streetcode.XUnitTest.MediatRTests.Streetcode.RelatedTerm
     {
         private readonly Mock<IMapper> _mapperMock;
         private readonly Mock<IRepositoryWrapper> _repositoryMock;
-        private readonly Mock<ILoggerService> _loggerMock;
         private readonly CreateRelatedTermHandler _handler;
 
         public CreateRelatedTermHandlerTests()
         {
             _mapperMock = new Mock<IMapper>();
             _repositoryMock = new Mock<IRepositoryWrapper>();
-            _loggerMock = new Mock<ILoggerService>();
-            _handler = new CreateRelatedTermHandler(_repositoryMock.Object, _mapperMock.Object, _loggerMock.Object);
+            _handler = new CreateRelatedTermHandler(_repositoryMock.Object, _mapperMock.Object);
         }
 
         [Fact]
         public async Task Handle_CreatesRelatedTermsDTO_WhenDTOFormed()
         {
             // Arrange
-            var relatedTermsDTO = new RelatedTermDto();
+            var relatedTermsDTO = new RelatedTermCreateDto("word", 1);
             var query = new CreateRelatedTermCommand(relatedTermsDTO);
             var relatedTerms = new List<RelatedTermEntity>();
             var entity = new RelatedTermEntity();
@@ -50,8 +47,8 @@ namespace Streetcode.XUnitTest.MediatRTests.Streetcode.RelatedTerm
             _repositoryMock.Setup(r => r.SaveChangesAsync())
                 .ReturnsAsync(1);
 
-            _mapperMock.Setup(m => m.Map<RelatedTermDto>(entity))
-                .Returns(relatedTermsDTO);
+            // _mapperMock.Setup(m => m.Map<RelatedTermDto>(entity))
+            //     .Returns(relatedTermsDTO);
 
             // Act
             var result = await _handler.Handle(query, CancellationToken.None);
@@ -66,7 +63,7 @@ namespace Streetcode.XUnitTest.MediatRTests.Streetcode.RelatedTerm
         public async Task Handle_ReturnsError_WhenRelatedTermIsNull()
         {
             // Arrange
-            var relatedTermsDTO = new RelatedTermDto();
+            var relatedTermsDTO = new RelatedTermCreateDto("word", 1);
             var query = new CreateRelatedTermCommand(relatedTermsDTO);
             var relatedTerms = new List<RelatedTermEntity>(); 
             var entity = new RelatedTermEntity();
@@ -81,14 +78,14 @@ namespace Streetcode.XUnitTest.MediatRTests.Streetcode.RelatedTerm
             // Assert
             result.IsSuccess.Should().BeFalse();
             result.Errors.Should().Contain(error => error.Message == "Cannot create new related word for a term!");
-            _loggerMock.Verify(l => l.LogError(It.IsAny<object>(), "Cannot create new related word for a term!"), Times.Once);
+            // _loggerMock.Verify(l => l.LogError(It.IsAny<object>(), "Cannot create new related word for a term!"), Times.Once);
         }
 
         [Fact]
         public async Task Handle_ReturnsError_WhenExistingTermsAreNull()
         {
             // Arrange
-            var relatedTermsDTO = new RelatedTermDto();
+            var relatedTermsDTO = new RelatedTermCreateDto("word", 1);
             var query = new CreateRelatedTermCommand(relatedTermsDTO);
             var relatedTerms = new List<RelatedTermEntity>(); 
             var entity = new RelatedTermEntity();
@@ -106,14 +103,14 @@ namespace Streetcode.XUnitTest.MediatRTests.Streetcode.RelatedTerm
             // Assert
             result.IsSuccess.Should().BeFalse();
             result.Errors.Should().Contain(error => error.Message == "Слово з цим визначенням уже існує");
-            _loggerMock.Verify(l => l.LogError(It.IsAny<object>(), "Слово з цим визначенням уже існує"), Times.Once);
+            // _loggerMock.Verify(l => l.LogError(It.IsAny<object>(), "Слово з цим визначенням уже існує"), Times.Once);
         }
 
         [Fact]
         public async Task Handle_ReturnsError_WhenSavingFailed()
         {
             // Arrange
-            var relatedTermsDTO = new RelatedTermDto();
+            var relatedTermsDTO = new RelatedTermCreateDto("word", 1);
             var query = new CreateRelatedTermCommand(relatedTermsDTO);
             var relatedTerms = new List<RelatedTermEntity>(); // Simulate no existing related terms
             var entity = new RelatedTermEntity();
@@ -138,14 +135,14 @@ namespace Streetcode.XUnitTest.MediatRTests.Streetcode.RelatedTerm
             // Assert
             result.IsSuccess.Should().BeFalse();
             result.Errors.Should().Contain(error => error.Message == "Cannot save changes in the database after related word creation!");
-            _loggerMock.Verify(l => l.LogError(It.IsAny<object>(), "Cannot save changes in the database after related word creation!"), Times.Once);
+            // _loggerMock.Verify(l => l.LogError(It.IsAny<object>(), "Cannot save changes in the database after related word creation!"), Times.Once);
         }
 
         [Fact]
         public async Task Handle_ReturnsError_WhenMappingToDtoFailed()
         {
             // Arrange
-            var relatedTermsDTO = new RelatedTermDto();
+            var relatedTermsDTO = new RelatedTermCreateDto("word", 1);
             var query = new CreateRelatedTermCommand(relatedTermsDTO);
             var relatedTerms = new List<RelatedTermEntity>(); 
             var entity = new RelatedTermEntity();
@@ -174,7 +171,7 @@ namespace Streetcode.XUnitTest.MediatRTests.Streetcode.RelatedTerm
             // Assert
             result.IsSuccess.Should().BeFalse();
             result.Errors.Should().Contain(error => error.Message == "Cannot map entity!");
-            _loggerMock.Verify(l => l.LogError(It.IsAny<object>(), "Cannot map entity!"), Times.Once);
+            // _loggerMock.Verify(l => l.LogError(It.IsAny<object>(), "Cannot map entity!"), Times.Once);
         }
     }
 }

--- a/Streetcode/Streetcode.XUnitTest/MediatRTests/Streetcode/RelatedTerm/CreateRelatedTermHandlerTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatRTests/Streetcode/RelatedTerm/CreateRelatedTermHandlerTests.cs
@@ -1,177 +1,213 @@
 ﻿using AutoMapper;
 using FluentAssertions;
 using Moq;
-using Streetcode.BLL.Interfaces.Logging;
 using Streetcode.BLL.MediatR.Streetcode.RelatedTerm.Create;
 using Streetcode.DAL.Repositories.Interfaces.Base;
 using System.Linq.Expressions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore.Query;
 using Streetcode.BLL.Dto.Streetcode.TextContent.Term;
+using Streetcode.BLL.Exceptions.CustomExceptions;
 using Xunit;
 
-using RelatedTermEntity = Streetcode.DAL.Entities.Streetcode.TextContent.RelatedTerm;
+namespace Streetcode.XUnitTest.MediatRTests.Streetcode.RelatedTerm;
 
-namespace Streetcode.XUnitTest.MediatRTests.Streetcode.RelatedTerm
+using RelatedTerm = DAL.Entities.Streetcode.TextContent.RelatedTerm;
+using Term = DAL.Entities.Streetcode.TextContent.Term;
+
+public class CreateRelatedTermHandlerTests
 {
-    public class CreateRelatedTermHandlerTests
+    private readonly Mock<IMapper> _mapperMock;
+    private readonly Mock<IRepositoryWrapper> _repositoryMock;
+    private readonly CreateRelatedTermHandler _handler;
+
+    public CreateRelatedTermHandlerTests()
     {
-        private readonly Mock<IMapper> _mapperMock;
-        private readonly Mock<IRepositoryWrapper> _repositoryMock;
-        private readonly CreateRelatedTermHandler _handler;
+        _mapperMock = new Mock<IMapper>();
+        _repositoryMock = new Mock<IRepositoryWrapper>();
+        _handler = new CreateRelatedTermHandler(_repositoryMock.Object, _mapperMock.Object);
+    }
 
-        public CreateRelatedTermHandlerTests()
-        {
-            _mapperMock = new Mock<IMapper>();
-            _repositoryMock = new Mock<IRepositoryWrapper>();
-            _handler = new CreateRelatedTermHandler(_repositoryMock.Object, _mapperMock.Object);
-        }
+    [Fact]
+    public async Task Handle_ThrowsCustomException_WhenRelatedTermIsNotMapped()
+    {
+        // Arrange
+        var relatedTermCreatDto = new RelatedTermCreateDto("word", 1);
+        var command = new CreateRelatedTermCommand(relatedTermCreatDto);
+        
+        RepositoryMockSetup(existing: new RelatedTerm(), created: null!, savedChanges: 0, term: null!);
+        MapperMockSetup(relatedTerm: null!, relatedTermFullDto: null!);
 
+        // Act
+        var exception =
+            await Assert.ThrowsAsync<CustomException>(() => _handler.Handle(command, CancellationToken.None));
+        
+        // Assert
+        Assert.Equal("Error while mapping RelatedTerm to RelatedTermFullDto", exception.Message);
+        Assert.Equal(StatusCodes.Status400BadRequest, exception.StatusCode);
+        _repositoryMock.Verify(repo => repo.RelatedTermRepository.CreateAsync(It.IsAny<RelatedTerm>()), Times.Never);
+        _repositoryMock.Verify(repo => repo.SaveChangesAsync(), Times.Never);
+    }
+    
+    [Fact]
+    public async Task Handle_ReturnsRelatedTermWithTerm_WhenRelatedTermExistsAndMapped()
+    {
+        // Arrange
+        var relatedTermCreatDto = new RelatedTermCreateDto("word", 1);
+        var command = new CreateRelatedTermCommand(relatedTermCreatDto);
+        var relatedTermFullDto = new RelatedTermFullDto(1, "word", new TermDto());
+        
+        RepositoryMockSetup(existing: new RelatedTerm(), created: null!, savedChanges: 0, term: null!);
+        MapperMockSetup(relatedTerm: null!, relatedTermFullDto: relatedTermFullDto);
+    
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeEquivalentTo(relatedTermFullDto);
+        _repositoryMock.Verify(repo => repo.RelatedTermRepository.CreateAsync(It.IsAny<RelatedTerm>()), Times.Never);
+        _repositoryMock.Verify(repo => repo.SaveChangesAsync(), Times.Never);
+    }
+    
+    [Fact]
+    public async Task Handle_ThrowsCustomException_WhenRelatedTermNotExistsAndDtoNotMapped()
+    {
+        // Arrange
+        var relatedTermCreatDto = new RelatedTermCreateDto("word", 1);
+        var command = new CreateRelatedTermCommand(relatedTermCreatDto);
+        
+        RepositoryMockSetup(existing: null, created: null!, savedChanges: 0, term: null!);
+        MapperMockSetup(relatedTerm: null!, relatedTermFullDto: null!);
+
+        // Act
+        var exception =
+            await Assert.ThrowsAsync<CustomException>(() => _handler.Handle(command, CancellationToken.None));
+        
+        // Assert
+        Assert.Equal("Error while mapping RelatedTermCreateDto to RelatedTerm", exception.Message);
+        Assert.Equal(StatusCodes.Status400BadRequest, exception.StatusCode);
+        _repositoryMock.Verify(repo => repo.RelatedTermRepository.CreateAsync(It.IsAny<RelatedTerm>()), Times.Never);
+        _repositoryMock.Verify(repo => repo.SaveChangesAsync(), Times.Never);
+    }
+    
+    [Fact]
+    public async Task Handle_ThrowsCustomException_WhenChangesNotSaved()
+    {
+        // Arrange
+        var relatedTermCreatDto = new RelatedTermCreateDto("word", 1);
+        var command = new CreateRelatedTermCommand(relatedTermCreatDto);
+        var relatedTerm = new RelatedTerm();
+        
+        RepositoryMockSetup(existing: null, created: relatedTerm, savedChanges: 0, term: null!);
+        MapperMockSetup(relatedTerm: relatedTerm, relatedTermFullDto: null!);
+
+        // Act
+        var exception =
+            await Assert.ThrowsAsync<CustomException>(() => _handler.Handle(command, CancellationToken.None));
+        
+        // Assert
+        Assert.Equal("No changes made", exception.Message);
+        Assert.Equal(StatusCodes.Status500InternalServerError, exception.StatusCode);
+        _repositoryMock.Verify(repo => repo.RelatedTermRepository.CreateAsync(It.IsAny<RelatedTerm>()), Times.Once);
+        _repositoryMock.Verify(repo => repo.SaveChangesAsync(), Times.Once);
+    }
+    
+    [Fact]
+    public async Task Handle_ThrowsCustomException_WhenTermIsNotLoadedIntoCreatedRelatedTerm()
+    {
+        // Arrange
+        var relatedTermCreatDto = new RelatedTermCreateDto("word", 1);
+        var command = new CreateRelatedTermCommand(relatedTermCreatDto);
+        var relatedTerm = new RelatedTerm();
+        
+        RepositoryMockSetup(existing: null, created: relatedTerm, savedChanges: 1, term: null!);
+        MapperMockSetup(relatedTerm: relatedTerm, relatedTermFullDto: null!);
+        
+        // Act
+        var exception =
+            await Assert.ThrowsAsync<CustomException>(() => _handler.Handle(command, CancellationToken.None));
+        
+        // Assert
+        Assert.Equal("Related Term not existing", exception.Message);
+        Assert.Equal(StatusCodes.Status500InternalServerError, exception.StatusCode);
+        _repositoryMock.Verify(repo => repo.RelatedTermRepository.CreateAsync(It.IsAny<RelatedTerm>()), Times.Once);
+        _repositoryMock.Verify(repo => repo.SaveChangesAsync(), Times.Once);
+    }
+    
+    [Fact]
+    public async Task Handle_ThrowsCustomException_WhenCreatedRelatedTermNotMapped()
+    {
+        // Arrange
+        var relatedTermCreatDto = new RelatedTermCreateDto("word", 1);
+        var command = new CreateRelatedTermCommand(relatedTermCreatDto);
+        var relatedTerm = new RelatedTerm();
+        
+        RepositoryMockSetup(existing: null, created: relatedTerm, savedChanges: 1, term: new Term());
+        MapperMockSetup(relatedTerm: relatedTerm, relatedTermFullDto: null!);
+        
+        // Act
+        var exception =
+            await Assert.ThrowsAsync<CustomException>(() => _handler.Handle(command, CancellationToken.None));
+        
+        // Assert
+        Assert.Equal("Error while mapping RelatedTerm to RelatedTermFullDto", exception.Message);
+        Assert.Equal(StatusCodes.Status400BadRequest, exception.StatusCode);
+        _repositoryMock.Verify(repo => repo.RelatedTermRepository.CreateAsync(It.IsAny<RelatedTerm>()), Times.Once);
+        _repositoryMock.Verify(repo => repo.SaveChangesAsync(), Times.Once);
+    }
+    
         [Fact]
-        public async Task Handle_CreatesRelatedTermsDTO_WhenDTOFormed()
-        {
-            // Arrange
-            var relatedTermsDTO = new RelatedTermCreateDto("word", 1);
-            var query = new CreateRelatedTermCommand(relatedTermsDTO);
-            var relatedTerms = new List<RelatedTermEntity>();
-            var entity = new RelatedTermEntity();
+    public async Task Handle_ReturnsRelatedTermFullDto_WhenRelatedTermCreatedAndMapped()
+    {
+        // Arrange
+        var relatedTermCreatDto = new RelatedTermCreateDto("word", 1);
+        var command = new CreateRelatedTermCommand(relatedTermCreatDto);
+        var relatedTerm = new RelatedTerm();
+        var relatedTermFullDto = new RelatedTermFullDto(1, "word", new TermDto());
+        
+        RepositoryMockSetup(existing: null, created: relatedTerm, savedChanges: 1, term: new Term());
+        MapperMockSetup(relatedTerm: relatedTerm, relatedTermFullDto: relatedTermFullDto);
 
-            _mapperMock.Setup(m => m.Map<RelatedTermEntity>(query.RelatedTerm))  
-                .Returns(entity);
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeEquivalentTo(relatedTermFullDto);
+        _repositoryMock.Verify(repo => repo.RelatedTermRepository.CreateAsync(It.IsAny<RelatedTerm>()), Times.Once);
+        _repositoryMock.Verify(repo => repo.SaveChangesAsync(), Times.Once);
+    }
 
-            _repositoryMock.Setup(r => r.RelatedTermRepository.GetAllAsync(
-                    It.IsAny<Expression<Func<RelatedTermEntity, bool>>>(), null))
-                .ReturnsAsync(relatedTerms);
+    private void RepositoryMockSetup(RelatedTerm? existing, RelatedTerm created, int savedChanges, Term term)
+    {
+        _repositoryMock
+            .Setup(repo => repo.RelatedTermRepository
+                .GetFirstOrDefaultAsync(
+                    It.IsAny<Expression<Func<RelatedTerm, bool>>>(),
+                    It.IsAny<Func<IQueryable<RelatedTerm>, IIncludableQueryable<RelatedTerm, object>>>()))
+            .ReturnsAsync(existing);
+        _repositoryMock
+            .Setup(repo => repo.RelatedTermRepository.CreateAsync(It.IsAny<RelatedTerm>()))
+            .ReturnsAsync(created);
+        _repositoryMock
+            .Setup(repo => repo.SaveChangesAsync())
+            .ReturnsAsync(savedChanges);
+        _repositoryMock
+            .Setup(repo => repo.TermRepository
+                .GetFirstOrDefaultAsync(
+                    It.IsAny<Expression<Func<Term, bool>>>(),
+                    It.IsAny<Func<IQueryable<Term>, IIncludableQueryable<Term, object>>>()))
+            .ReturnsAsync(term);
+    }
 
-            _repositoryMock.Setup(r => r.RelatedTermRepository.CreateAsync(It.IsAny<RelatedTermEntity>()))
-                .ReturnsAsync(entity);
-
-            _repositoryMock.Setup(r => r.SaveChangesAsync())
-                .ReturnsAsync(1);
-
-            // _mapperMock.Setup(m => m.Map<RelatedTermDto>(entity))
-            //     .Returns(relatedTermsDTO);
-
-            // Act
-            var result = await _handler.Handle(query, CancellationToken.None);
-
-            // Assert
-            result.IsSuccess.Should().BeTrue();
-            result.Value.Should().BeEquivalentTo(relatedTermsDTO);
-        }
-
-
-        [Fact]
-        public async Task Handle_ReturnsError_WhenRelatedTermIsNull()
-        {
-            // Arrange
-            var relatedTermsDTO = new RelatedTermCreateDto("word", 1);
-            var query = new CreateRelatedTermCommand(relatedTermsDTO);
-            var relatedTerms = new List<RelatedTermEntity>(); 
-            var entity = new RelatedTermEntity();
-
-
-            _mapperMock.Setup(m => m.Map<RelatedTermEntity>(query.RelatedTerm)) 
-                .Returns((RelatedTermEntity)null);
-
-            // Act
-            var result = await _handler.Handle(query, CancellationToken.None);
-
-            // Assert
-            result.IsSuccess.Should().BeFalse();
-            result.Errors.Should().Contain(error => error.Message == "Cannot create new related word for a term!");
-            // _loggerMock.Verify(l => l.LogError(It.IsAny<object>(), "Cannot create new related word for a term!"), Times.Once);
-        }
-
-        [Fact]
-        public async Task Handle_ReturnsError_WhenExistingTermsAreNull()
-        {
-            // Arrange
-            var relatedTermsDTO = new RelatedTermCreateDto("word", 1);
-            var query = new CreateRelatedTermCommand(relatedTermsDTO);
-            var relatedTerms = new List<RelatedTermEntity>(); 
-            var entity = new RelatedTermEntity();
-
-
-            _mapperMock.Setup(m => m.Map<RelatedTermEntity>(query.RelatedTerm)).Returns(entity);
-
-            _repositoryMock.Setup(r => r.RelatedTermRepository.GetAllAsync(
-                    It.IsAny<Expression<Func<RelatedTermEntity, bool>>>(), null))
-                .ReturnsAsync((IEnumerable<RelatedTermEntity>)null);
-
-            // Act
-            var result = await _handler.Handle(query, CancellationToken.None);
-
-            // Assert
-            result.IsSuccess.Should().BeFalse();
-            result.Errors.Should().Contain(error => error.Message == "Слово з цим визначенням уже існує");
-            // _loggerMock.Verify(l => l.LogError(It.IsAny<object>(), "Слово з цим визначенням уже існує"), Times.Once);
-        }
-
-        [Fact]
-        public async Task Handle_ReturnsError_WhenSavingFailed()
-        {
-            // Arrange
-            var relatedTermsDTO = new RelatedTermCreateDto("word", 1);
-            var query = new CreateRelatedTermCommand(relatedTermsDTO);
-            var relatedTerms = new List<RelatedTermEntity>(); // Simulate no existing related terms
-            var entity = new RelatedTermEntity();
-
-
-            _mapperMock.Setup(m => m.Map<RelatedTermEntity>(query.RelatedTerm)) 
-                            .Returns(entity);
-
-            _repositoryMock.Setup(r => r.RelatedTermRepository.GetAllAsync(
-                    It.IsAny<Expression<Func<RelatedTermEntity, bool>>>(), null))
-                .ReturnsAsync(relatedTerms);
-
-            _repositoryMock.Setup(r => r.RelatedTermRepository.Create(It.IsAny<RelatedTermEntity>()))
-                .Returns(entity);
-
-            _repositoryMock.Setup(r => r.SaveChangesAsync())
-                .ReturnsAsync(0); 
-
-            // Act
-            var result = await _handler.Handle(query, CancellationToken.None);
-
-            // Assert
-            result.IsSuccess.Should().BeFalse();
-            result.Errors.Should().Contain(error => error.Message == "Cannot save changes in the database after related word creation!");
-            // _loggerMock.Verify(l => l.LogError(It.IsAny<object>(), "Cannot save changes in the database after related word creation!"), Times.Once);
-        }
-
-        [Fact]
-        public async Task Handle_ReturnsError_WhenMappingToDtoFailed()
-        {
-            // Arrange
-            var relatedTermsDTO = new RelatedTermCreateDto("word", 1);
-            var query = new CreateRelatedTermCommand(relatedTermsDTO);
-            var relatedTerms = new List<RelatedTermEntity>(); 
-            var entity = new RelatedTermEntity();
-
-
-            _mapperMock.Setup(m => m.Map<RelatedTermEntity>(query.RelatedTerm))
-                            .Returns(entity);
-
-            _repositoryMock.Setup(r => r.RelatedTermRepository.GetAllAsync(
-                    It.IsAny<Expression<Func<RelatedTermEntity, bool>>>(), null))
-                .ReturnsAsync(relatedTerms);
-
-            _repositoryMock.Setup(r => r.RelatedTermRepository.Create(It.IsAny<RelatedTermEntity>()))
-                .Returns(entity);
-
-            _repositoryMock.Setup(r => r.SaveChangesAsync())
-                .ReturnsAsync(1);
-
-            _mapperMock.Setup(m => m.Map<RelatedTermDto>(entity))
-                .Returns((RelatedTermDto)null);
-
-
-            // Act
-            var result = await _handler.Handle(query, CancellationToken.None);
-
-            // Assert
-            result.IsSuccess.Should().BeFalse();
-            result.Errors.Should().Contain(error => error.Message == "Cannot map entity!");
-            // _loggerMock.Verify(l => l.LogError(It.IsAny<object>(), "Cannot map entity!"), Times.Once);
-        }
+    private void MapperMockSetup(RelatedTerm relatedTerm, RelatedTermFullDto relatedTermFullDto)
+    {
+        _mapperMock
+            .Setup(mapper => mapper.Map<RelatedTerm>(It.IsAny<RelatedTermCreateDto>()))
+            .Returns(relatedTerm);
+        _mapperMock
+            .Setup(mapper => mapper.Map<RelatedTermFullDto>(It.IsAny<RelatedTerm?>()))
+            .Returns(relatedTermFullDto);
     }
 }


### PR DESCRIPTION
dev
## Summary of issue

Rework add related term functionctionality to return all necessary data about related term, use proper Dto for creating and replace error handling in Handler with global exception middleware.
- Previously `RelatedTermDto` was used to send a request to create a related term. This Dto contains `Id` that is redundant for this purpose.
- Handler have been returning `ReleatedTermDto` that does not contain info about `Term`. Technically, it have been returning just a word without it's meaning.
- Errors were handled inside of Mediator.

## Summary of change
- Added `RelatedTermCreateDto`
- Configured mapping from `RelatedTermCreateDto` to `RelatedTerm` and from `RelatedTerm` to `RelatedTermFullDto`
- Changed `CreateRelatedTermCommand` to accept `RelatedTermCreateDto` as a parameter and return result of type `RelatedTermFullDto`
- Changed `Handle` method to check for existing related term first and return it instead of error. If same related term already exists we should just return this related term and not throwing an error. This is just a process of linking a word to a term.
- As a method result we return now related term with the term it linked to. So now frontend can have meaning of this word without making extra request for this.
- Instead of hadling errors and returning failure result in Handle method, Custom exceptions with status code are thrown  and handled by global exception middleware.
- Added unit tests for mapping config and handler.

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=50%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  PR meets all conventions
