### PR TITLE
Feat/157/admin art delete streetcode art

### DIFF
--- a/Streetcode/Streetcode.BLL/MediatR/Media/Art/Delete/DeleteArtHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Media/Art/Delete/DeleteArtHandler.cs
@@ -1,7 +1,6 @@
 ﻿using FluentResults;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
-using Streetcode.BLL.Interfaces.BlobStorage;
 using Streetcode.BLL.Interfaces.Logging;
 using Streetcode.DAL.Repositories.Interfaces.Base;
 
@@ -10,13 +9,11 @@ namespace Streetcode.BLL.MediatR.Media.Art.Delete
     public class DeleteArtHandler: IRequestHandler<DeleteArtCommand, Result<Unit>>
     {
         private readonly IRepositoryWrapper _repositoryWrapper;
-        private readonly IBlobService _blobService;
         private readonly ILoggerService _logger;
 
-        public DeleteArtHandler(IRepositoryWrapper repositoryWrapper, IBlobService blobService ,ILoggerService logger) 
+        public DeleteArtHandler(IRepositoryWrapper repositoryWrapper, ILoggerService logger) 
         {
             _repositoryWrapper = repositoryWrapper;
-            _blobService = blobService;
             _logger = logger;
         }
 
@@ -38,7 +35,6 @@ namespace Streetcode.BLL.MediatR.Media.Art.Delete
             if (art.Image != null) 
             {
                 _repositoryWrapper.ImageRepository.Delete(art.Image);
-                _blobService.DeleteFileInStorage(art.Image.BlobName!);
             }
 
             _repositoryWrapper.ArtRepository.Delete(art);

--- a/Streetcode/Streetcode.XUnitTest/MediatRTests/Media/Art/DeleteArtHandlerTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatRTests/Media/Art/DeleteArtHandlerTests.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.EntityFrameworkCore.Query;
 using Moq;
-using Streetcode.BLL.Interfaces.BlobStorage;
 using Streetcode.BLL.Interfaces.Logging;
 using Streetcode.BLL.MediatR.Media.Art.Delete;
 using Streetcode.DAL.Repositories.Interfaces.Base;
@@ -15,16 +14,14 @@ namespace Streetcode.XUnitTest.MediatRTests.Media.Art
     public class DeleteArtHandlerTests
     {
         private readonly Mock<IRepositoryWrapper> _repositoryWrapperMock;
-        private readonly Mock<IBlobService> _blobServiceMock;
         private readonly Mock<ILoggerService> _loggerMock;
         private readonly DeleteArtHandler _handler;
 
         public DeleteArtHandlerTests()
         {
             _repositoryWrapperMock = new Mock<IRepositoryWrapper>();
-            _blobServiceMock = new Mock<IBlobService>();
             _loggerMock = new Mock<ILoggerService>();
-            _handler = new DeleteArtHandler(_repositoryWrapperMock.Object, _blobServiceMock.Object, _loggerMock.Object);
+            _handler = new DeleteArtHandler(_repositoryWrapperMock.Object, _loggerMock.Object);
         }
 
         [Fact]
@@ -63,7 +60,6 @@ namespace Streetcode.XUnitTest.MediatRTests.Media.Art
                 It.IsAny<Func<IQueryable<ArtEntity>, IIncludableQueryable<ArtEntity, object>>>())).ReturnsAsync(art);
 
             _repositoryWrapperMock.Setup(repo => repo.ImageRepository.Delete(art.Image));
-            _blobServiceMock.Setup(blob => blob.DeleteFileInStorage("image1"));
             _repositoryWrapperMock.Setup(repo => repo.ArtRepository.Delete(art));
             _repositoryWrapperMock.Setup(repo => repo.SaveChangesAsync()).ReturnsAsync(1);
 


### PR DESCRIPTION
dev
## Summary of issue
Removed file deleting in DeleteArtHandler

## Summary of change
Removed the ability to delete an image from Blob Storage in DeleteArtHandler, fixed unit tests

## Comments

ToDo

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=50%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  PR meets all conventions
