### PR TITLE
feat/171/ rework delete related term functionality

### DIFF
--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/RelatedTerm/Delete/DeleteRelatedTermCommand.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/RelatedTerm/Delete/DeleteRelatedTermCommand.cs
@@ -1,9 +1,6 @@
 ﻿using FluentResults;
 using MediatR;
-using Streetcode.BLL.Dto.Streetcode.TextContent;
-using Streetcode.BLL.Dto.Streetcode.TextContent.Term;
 
-namespace Streetcode.BLL.MediatR.Streetcode.RelatedTerm.Delete
-{
-    public record DeleteRelatedTermCommand(string word): IRequest<Result<RelatedTermDto>>;
-}
+namespace Streetcode.BLL.MediatR.Streetcode.RelatedTerm.Delete;
+
+public record DeleteRelatedTermCommand(string Word, int TermId): IRequest<Result<Unit>>;

--- a/Streetcode/Streetcode.DAL/Entities/Streetcode/TextContent/RelatedTerm.cs
+++ b/Streetcode/Streetcode.DAL/Entities/Streetcode/TextContent/RelatedTerm.cs
@@ -10,9 +10,9 @@ namespace Streetcode.DAL.Entities.Streetcode.TextContent
         [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
         public int Id { get; set; }
 
-        [Required]
-        [MaxLength(50)]
-        public string? Word { get; set; }
+        [Required] 
+        [MaxLength(50)] 
+        public string Word { get; set; } = null!;
         
         [Required]
         public int TermId { get; set; }

--- a/Streetcode/Streetcode.WebApi/Controllers/Streetcode/TextContent/RelatedTermController.cs
+++ b/Streetcode/Streetcode.WebApi/Controllers/Streetcode/TextContent/RelatedTermController.cs
@@ -28,10 +28,10 @@ namespace Streetcode.WebApi.Controllers.Streetcode.TextContent
             return HandleResult(await Mediator.Send(new UpdateRelatedTermCommand(id, relatedTerm)));
         }
 
-        [HttpDelete("{word}")]
-        public async Task<IActionResult> Delete([FromRoute] string word)
+        [HttpDelete("{word}/{termId:int}")]
+        public async Task<IActionResult> Delete([FromRoute] string word, [FromRoute] int termId)
         {
-            return HandleResult(await Mediator.Send(new DeleteRelatedTermCommand(word)));
+            return HandleResult(await Mediator.Send(new DeleteRelatedTermCommand(word, termId)));
         }
     }
 }

--- a/Streetcode/Streetcode.XUnitTest/MappingTests/Streetcode/TextContent/RelatedTermProfileTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/MappingTests/Streetcode/TextContent/RelatedTermProfileTests.cs
@@ -53,7 +53,7 @@ public class RelatedTermProfileTests
     public void RelatedTermCreateDto_ShouldMapTo_RelatedTerm()
     {
         // Arrange
-        var createDto = new RelatedTermCreateDto("word", 1);
+        var createDto = new RelatedTermCreateDto("Word", 1);
 
         // Act
         var relatedTerm = _mapper.Map<RelatedTerm>(createDto);


### PR DESCRIPTION
dev
## Summary of issue

Rework delete related term to make it work correctly.

## Summary of change

- `DeleteRelatedTermCommand` now accepts 2 parameters: word to delete and id of term with it relates to. One word can have different meanings and relate to different terms.
- Property `Word` of `RelatedTerm` entity in now not nullable because every related term must have word.
- Handler now searches for related term to delete by word and id of term. After delete it returns successfull task without dto. We don't need to send dto of deleted entity to frontend in this user story.
- Used CustomException and GlobalExceptionHandler instead of hanlding errors inside the handler.
- Word and TermId are passes in the route of http request to controller.
- Rewrite unit tests for handler according to new implementation.

## Comments

ToDo

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=50%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  PR meets all conventions
