### PR TITLE
Feat/81/add text

### DIFF
--- a/Streetcode/Streetcode.BLL/Dto/Streetcode/TextContent/Text/TextCreateDto.cs
+++ b/Streetcode/Streetcode.BLL/Dto/Streetcode/TextContent/Text/TextCreateDto.cs
@@ -1,9 +1,9 @@
-namespace Streetcode.BLL.Dto.Streetcode.TextContent.Text
+namespace Streetcode.BLL.Dto.Streetcode.TextContent.Text;
+
+public class TextCreateDto
 {
-  public class TextCreateDto
-  {
     public string Title { get; set; } = null!;
     public string TextContent { get; set; } = null!;
     public string? AdditionalText { get; set; }
-  }
+    public int StreetcodeId { get; set; }
 }

--- a/Streetcode/Streetcode.BLL/Mapping/Streetcode/TextContent/TextProfile.cs
+++ b/Streetcode/Streetcode.BLL/Mapping/Streetcode/TextContent/TextProfile.cs
@@ -9,6 +9,6 @@ public class TextProfile : Profile
     public TextProfile()
     {
         CreateMap<Text, TextDto>().ReverseMap();
-        CreateMap<TextCreateDto, Text>().ReverseMap();
+        CreateMap<TextCreateDto, Text>();
     }
 }

--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Text/Create/CreateTextCommand.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Text/Create/CreateTextCommand.cs
@@ -1,0 +1,7 @@
+using FluentResults;
+using MediatR;
+using Streetcode.BLL.Dto.Streetcode.TextContent.Text;
+
+namespace Streetcode.BLL.MediatR.Streetcode.Text.Create;
+
+public record CreateTextCommand(TextCreateDto TextCreateDto): IRequest<Result<TextDto>>;

--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Text/Create/CreateTextCommandValidator.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Text/Create/CreateTextCommandValidator.cs
@@ -1,0 +1,31 @@
+using FluentValidation;
+
+namespace Streetcode.BLL.MediatR.Streetcode.Text.Create;
+
+public class CreateTextCommandValidator: AbstractValidator<CreateTextCommand>
+{
+    private const int TitleMaxLength = 300;
+    private const int TextContentMaxLength = 15000;
+    private const int AdditionalTextMaxLength = 200;
+    
+    public CreateTextCommandValidator()
+    {
+        RuleFor(x => x.TextCreateDto.Title)
+            .NotEmpty()
+            .WithMessage("Text title is required")
+            .MaximumLength(TitleMaxLength)
+            .WithMessage($"Text title must not exceed {TitleMaxLength} chars");
+        
+        RuleFor(x => x.TextCreateDto.TextContent)
+            .NotEmpty()
+            .WithMessage("Text content is required")
+            .MaximumLength(TextContentMaxLength)
+            .WithMessage($"Text content must not exceed {TextContentMaxLength} chars");
+        
+        RuleFor(x => x.TextCreateDto.AdditionalText)
+            .NotEmpty()
+            .WithMessage("Text additional text is required")
+            .MaximumLength(AdditionalTextMaxLength)
+            .WithMessage($"Text additional text must not exceed {AdditionalTextMaxLength} chars");
+    }
+}

--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Text/Create/CreateTextCommandValidator.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Text/Create/CreateTextCommandValidator.cs
@@ -27,5 +27,9 @@ public class CreateTextCommandValidator: AbstractValidator<CreateTextCommand>
             .WithMessage("Text additional text is required")
             .MaximumLength(AdditionalTextMaxLength)
             .WithMessage($"Text additional text must not exceed {AdditionalTextMaxLength} chars");
+        
+        RuleFor(x => x.TextCreateDto.StreetcodeId)
+            .GreaterThan(0)
+            .WithMessage("Text StreetcodeId must be > 0");
     }
 }

--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Text/Create/CreateTextHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Text/Create/CreateTextHandler.cs
@@ -1,0 +1,44 @@
+using AutoMapper;
+using FluentResults;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using Streetcode.BLL.Dto.Streetcode.TextContent.Text;
+using Streetcode.BLL.Exceptions.CustomExceptions;
+using Streetcode.DAL.Repositories.Interfaces.Base;
+
+namespace Streetcode.BLL.MediatR.Streetcode.Text.Create;
+
+using Text = DAL.Entities.Streetcode.TextContent.Text;
+
+public class CreateTextHandler: IRequestHandler<CreateTextCommand, Result<TextDto>>
+{
+    private readonly IRepositoryWrapper _repositoryWrapper;
+    private readonly IMapper _mapper;
+
+    public CreateTextHandler(IRepositoryWrapper repositoryWrapper, IMapper mapper)
+    {
+        _repositoryWrapper = repositoryWrapper;
+        _mapper = mapper;
+    }
+    
+    public async Task<Result<TextDto>> Handle(CreateTextCommand request, CancellationToken cancellationToken)
+    {
+        var text = _mapper.Map<Text>(request.TextCreateDto) ?? throw new CustomException(
+            "Error while mapping TextCreateDto to Text",
+            StatusCodes.Status400BadRequest);
+
+        var createdText = await _repositoryWrapper.TextRepository.CreateAsync(text);
+        var isResultSuccess = await _repositoryWrapper.SaveChangesAsync() == 1;
+
+        if (!isResultSuccess)
+        {
+            throw new CustomException("No changes saved", StatusCodes.Status500InternalServerError);
+        }
+
+        var createdTextDto = _mapper.Map<TextDto>(createdText) ?? throw new CustomException(
+            "Error while mapping Text to TextDto", 
+            StatusCodes.Status400BadRequest);
+
+        return Result.Ok(createdTextDto);
+    }
+}

--- a/Streetcode/Streetcode.WebApi/Controllers/Streetcode/TextContent/TextController.cs
+++ b/Streetcode/Streetcode.WebApi/Controllers/Streetcode/TextContent/TextController.cs
@@ -1,6 +1,8 @@
 using FluentResults;
 using Microsoft.AspNetCore.Mvc;
 using Streetcode.BLL.Dto.Streetcode.TextContent;
+using Streetcode.BLL.Dto.Streetcode.TextContent.Text;
+using Streetcode.BLL.MediatR.Streetcode.Text.Create;
 using Streetcode.BLL.MediatR.Streetcode.Text.GetAll;
 using Streetcode.BLL.MediatR.Streetcode.Text.GetById;
 using Streetcode.BLL.MediatR.Streetcode.Text.GetByStreetcodeId;
@@ -32,5 +34,11 @@ public class TextController : BaseApiController
     public async Task<IActionResult> GetParsedText([FromQuery] string text)
     {
         return HandleResult(await Mediator.Send(new GetParsedTextForAdminPreviewCommand(text)));
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Create([FromBody] TextCreateDto textCreateDto)
+    {
+        return HandleResult(await Mediator.Send(new CreateTextCommand(textCreateDto)));
     }
 }

--- a/Streetcode/Streetcode.XUnitTest/MappingTests/Streetcode/TextContent/TextProfileTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/MappingTests/Streetcode/TextContent/TextProfileTests.cs
@@ -1,0 +1,93 @@
+using AutoMapper;
+using FluentAssertions;
+using Streetcode.BLL.Dto.Streetcode.TextContent.Text;
+using Streetcode.BLL.Mapping.Streetcode.TextContent;
+using Streetcode.DAL.Entities.Streetcode.TextContent;
+using Xunit;
+
+namespace Streetcode.XUnitTest.MappingTests.Streetcode.TextContent;
+
+public class TextProfileTests
+{
+    private readonly IMapper _mapper;
+
+    public TextProfileTests()
+    {
+        var config = new MapperConfiguration(cfg =>
+        {
+            cfg.AddProfile<TextProfile>();
+        });
+
+        _mapper = config.CreateMapper();
+    }
+
+    [Fact]
+    public void Text_ShouldMapTo_TextDto()
+    {
+        // Arrange
+        var text = new Text
+        {
+            Id = 1,
+            Title = "Title",
+            TextContent = "TextContent",
+            AdditionalText = "AdditionalText",
+            StreetcodeId = 1,
+        };
+        
+        // Act
+        var textDto = _mapper.Map<TextDto>(text);
+        
+        // Assert
+        textDto.Id.Should().Be(text.Id);
+        textDto.Title.Should().Be(text.Title);
+        textDto.TextContent.Should().Be(text.TextContent);
+        textDto.AdditionalText.Should().Be(text.AdditionalText);
+        textDto.StreetcodeId.Should().Be(text.StreetcodeId);
+    }
+
+    [Fact]
+    public void TextDto_ShouldMapTo_Text()
+    {
+        // Arrange
+        var textDto = new TextDto
+        {
+            Id = 1,
+            Title = "Title",
+            TextContent = "TextContent",
+            AdditionalText = "AdditionalText",
+            StreetcodeId = 1,
+        };
+        
+        // Act
+        var text = _mapper.Map<Text>(textDto);
+        
+        // Assert
+        text.Id.Should().Be(textDto.Id);
+        text.Title.Should().Be(textDto.Title);
+        text.TextContent.Should().Be(textDto.TextContent);
+        text.AdditionalText.Should().Be(textDto.AdditionalText);
+        text.StreetcodeId.Should().Be(textDto.StreetcodeId);
+    }
+
+    [Fact]
+    public void TextCreateDto_ShouldMapTo_Text()
+    {
+        // Arrange
+        var textDto = new TextCreateDto
+        {
+            Title = "Title",
+            TextContent = "TextContent",
+            AdditionalText = "AdditionalText",
+            StreetcodeId = 1,
+        };
+        
+        // Act
+        var text = _mapper.Map<Text>(textDto);
+        
+        // Assert
+        text.Title.Should().Be(textDto.Title);
+        text.TextContent.Should().Be(textDto.TextContent);
+        text.AdditionalText.Should().Be(textDto.AdditionalText);
+        text.StreetcodeId.Should().Be(textDto.StreetcodeId);
+    }
+}

--- a/Streetcode/Streetcode.XUnitTest/MediatRTests/Streetcode/Text/CreateTextCommandValidatorTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatRTests/Streetcode/Text/CreateTextCommandValidatorTests.cs
@@ -1,0 +1,188 @@
+using FluentValidation.TestHelper;
+using Streetcode.BLL.Dto.Streetcode.TextContent.Text;
+using Streetcode.BLL.MediatR.Streetcode.Text.Create;
+using Xunit;
+
+namespace Streetcode.XUnitTest.MediatRTests.Streetcode.Text;
+
+public class CreateTextCommandValidatorTests
+{
+    private const int TitleMaxLength = 300;
+    private const int TextContentMaxLength = 15000;
+    private const int AdditionalTextMaxLength = 200;
+    private readonly CreateTextCommandValidator _validator= new ();
+
+    [Fact]
+    public void Validator_ShouldFail_WhenTitleIsEmpty()
+    {
+        // Arrange
+        var invalidDto = new TextCreateDto
+        {
+            Title = "",
+            TextContent = "null",
+            AdditionalText = "null",
+            StreetcodeId = 1
+        };
+        var invalidCommand = new CreateTextCommand(invalidDto);
+
+        // Act
+        var result = _validator.TestValidate(invalidCommand);
+
+        // Assert
+        result
+            .ShouldHaveValidationErrorFor(x => x.TextCreateDto.Title)
+            .WithErrorMessage("Text title is required");
+    }
+    
+    [Fact]
+    public void Validator_ShouldFail_WhenTitleIsExceedsLengthLimit()
+    {
+        // Arrange
+        var invalidDto = new TextCreateDto
+        {
+            Title = new string ('1', 301),
+            TextContent = "null",
+            AdditionalText = "null",
+            StreetcodeId = 1
+        };
+        var invalidCommand = new CreateTextCommand(invalidDto);
+
+        // Act
+        var result = _validator.TestValidate(invalidCommand);
+
+        // Assert
+        result
+            .ShouldHaveValidationErrorFor(x => x.TextCreateDto.Title)
+            .WithErrorMessage($"Text title must not exceed {TitleMaxLength} chars");
+    }
+    
+    [Fact]
+    public void Validator_ShouldFail_WhenTextContentIsEmpty()
+    {
+        // Arrange
+        var invalidDto = new TextCreateDto
+        {
+            Title = "null",
+            TextContent = "",
+            AdditionalText = "null",
+            StreetcodeId = 1
+        };
+        var invalidCommand = new CreateTextCommand(invalidDto);
+
+        // Act
+        var result = _validator.TestValidate(invalidCommand);
+
+        // Assert
+        result
+            .ShouldHaveValidationErrorFor(x => x.TextCreateDto.TextContent)
+            .WithErrorMessage("Text content is required");
+    }
+    
+    [Fact]
+    public void Validator_ShouldFail_WhenTextContentIsExceedsLengthLimit()
+    {
+        // Arrange
+        var invalidDto = new TextCreateDto
+        {
+            Title = "null",
+            TextContent = new string('1', 15001),
+            AdditionalText = "null",
+            StreetcodeId = 1
+        };
+        var invalidCommand = new CreateTextCommand(invalidDto);
+
+        // Act
+        var result = _validator.TestValidate(invalidCommand);
+
+        // Assert
+        result
+            .ShouldHaveValidationErrorFor(x => x.TextCreateDto.TextContent)
+            .WithErrorMessage($"Text content must not exceed {TextContentMaxLength} chars");
+    }
+    
+    [Fact]
+    public void Validator_ShouldFail_WhenAdditionalTextIsEmpty()
+    {
+        // Arrange
+        var invalidDto = new TextCreateDto
+        {
+            Title = "null",
+            TextContent = "null",
+            AdditionalText = "",
+            StreetcodeId = 1
+        };
+        var invalidCommand = new CreateTextCommand(invalidDto);
+
+        // Act
+        var result = _validator.TestValidate(invalidCommand);
+
+        // Assert
+        result
+            .ShouldHaveValidationErrorFor(x => x.TextCreateDto.AdditionalText)
+            .WithErrorMessage("Text additional text is required");
+    }
+    
+    [Fact]
+    public void Validator_ShouldFail_WhenAdditionalTextIsExceedsLengthLimit()
+    {
+        // Arrange
+        var invalidDto = new TextCreateDto
+        {
+            Title = "null",
+            TextContent = "null",
+            AdditionalText = new string('1', 201),
+            StreetcodeId = 1
+        };
+        var invalidCommand = new CreateTextCommand(invalidDto);
+
+        // Act
+        var result = _validator.TestValidate(invalidCommand);
+
+        // Assert
+        result
+            .ShouldHaveValidationErrorFor(x => x.TextCreateDto.AdditionalText)
+            .WithErrorMessage($"Text additional text must not exceed {AdditionalTextMaxLength} chars");
+    }
+    
+    [Fact]
+    public void Validator_ShouldFail_WhenStreetcodeIdIsZeroOrNegative()
+    {
+        // Arrange
+        var invalidDto = new TextCreateDto
+        {
+            Title = "null",
+            TextContent = "null",
+            AdditionalText = "null",
+            StreetcodeId = 0
+        };
+        var invalidCommand = new CreateTextCommand(invalidDto);
+
+        // Act
+        var result = _validator.TestValidate(invalidCommand);
+
+        // Assert
+        result
+            .ShouldHaveValidationErrorFor(x => x.TextCreateDto.StreetcodeId)
+            .WithErrorMessage("Text StreetcodeId must be > 0");
+    }
+    
+    [Fact]
+    public void Validator_ShouldPass_WhenStreetcodeIdIsZeroOrNegative()
+    {
+        // Arrange
+        var invalidDto = new TextCreateDto
+        {
+            Title = "null",
+            TextContent = "null",
+            AdditionalText = "null",
+            StreetcodeId = 1
+        };
+        var invalidCommand = new CreateTextCommand(invalidDto);
+
+        // Act
+        var result = _validator.TestValidate(invalidCommand);
+
+        // Assert
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+}

--- a/Streetcode/Streetcode.XUnitTest/MediatRTests/Streetcode/Text/CreateTextHandlerTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/MediatRTests/Streetcode/Text/CreateTextHandlerTests.cs
@@ -1,0 +1,145 @@
+using AutoMapper;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Moq;
+using Streetcode.BLL.Dto.Streetcode.TextContent.Text;
+using Streetcode.BLL.Exceptions.CustomExceptions;
+using Streetcode.BLL.MediatR.Streetcode.Text.Create;
+using Streetcode.DAL.Repositories.Interfaces.Base;
+using Xunit;
+
+namespace Streetcode.XUnitTest.MediatRTests.Streetcode.Text;
+
+using Text = DAL.Entities.Streetcode.TextContent.Text;
+
+public class CreateTextHandlerTests
+{
+    private readonly Mock<IRepositoryWrapper> _repositoryMock;
+    private readonly Mock<IMapper> _mapperMock;
+    private readonly CreateTextHandler _handler;
+
+    public CreateTextHandlerTests()
+    {
+        _repositoryMock = new Mock<IRepositoryWrapper>();
+        _mapperMock = new Mock<IMapper>();
+        _handler = new CreateTextHandler(_repositoryMock.Object, _mapperMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldThrowCustomException_WhenTextIsNotMapped()
+    {
+        // Arrange
+        var textCreateDto = new TextCreateDto();
+        var command = new CreateTextCommand(textCreateDto);
+
+        _mapperMock
+            .Setup(mapper => mapper.Map<Text>(It.IsAny<TextCreateDto>()))
+            .Returns((Text)null!);
+        
+        // Act
+        var exception =
+            await Assert.ThrowsAsync<CustomException>(() => _handler.Handle(command, CancellationToken.None));
+        
+        // Assert
+        Assert.Equal("Error while mapping TextCreateDto to Text", exception.Message);
+        Assert.Equal(StatusCodes.Status400BadRequest, exception.StatusCode);
+        _repositoryMock.Verify(repo => repo.TextRepository.CreateAsync(It.IsAny<Text>()), Times.Never);
+        _repositoryMock.Verify(repo => repo.SaveChangesAsync(), Times.Never);
+    }
+    
+    [Fact]
+    public async Task Handle_ShouldThrowCustomException_WhenChangesNotSaved()
+    {
+        // Arrange
+        var textCreateDto = new TextCreateDto();
+        var command = new CreateTextCommand(textCreateDto);
+        var text = new Text();
+
+        _mapperMock
+            .Setup(mapper => mapper.Map<Text>(It.IsAny<TextCreateDto>()))
+            .Returns(text);
+
+        _repositoryMock
+            .Setup(repo => repo.TextRepository.CreateAsync(It.IsAny<Text>()))
+            .ReturnsAsync(text);
+        _repositoryMock
+            .Setup(repo => repo.SaveChangesAsync())
+            .ReturnsAsync(0);
+        
+        // Act
+        var exception =
+            await Assert.ThrowsAsync<CustomException>(() => _handler.Handle(command, CancellationToken.None));
+        
+        // Assert
+        Assert.Equal("No changes saved", exception.Message);
+        Assert.Equal(StatusCodes.Status500InternalServerError, exception.StatusCode);
+        _repositoryMock.Verify(repo => repo.TextRepository.CreateAsync(It.IsAny<Text>()), Times.Once);
+        _repositoryMock.Verify(repo => repo.SaveChangesAsync(), Times.Once);
+    }
+    
+    [Fact]
+    public async Task Handle_ShouldThrowCustomException_WhenTextDtoNotMapped()
+    {
+        // Arrange
+        var textCreateDto = new TextCreateDto();
+        var command = new CreateTextCommand(textCreateDto);
+        var text = new Text();
+
+        _mapperMock
+            .Setup(mapper => mapper.Map<Text>(It.IsAny<TextCreateDto>()))
+            .Returns(text);
+        _mapperMock
+            .Setup(mapper => mapper.Map<TextDto>(It.IsAny<Text>()))
+            .Returns((TextDto)null!);
+
+        _repositoryMock
+            .Setup(repo => repo.TextRepository.CreateAsync(It.IsAny<Text>()))
+            .ReturnsAsync(text);
+        _repositoryMock
+            .Setup(repo => repo.SaveChangesAsync())
+            .ReturnsAsync(1);
+        
+        // Act
+        var exception =
+            await Assert.ThrowsAsync<CustomException>(() => _handler.Handle(command, CancellationToken.None));
+        
+        // Assert
+        Assert.Equal("Error while mapping Text to TextDto", exception.Message);
+        Assert.Equal(StatusCodes.Status400BadRequest, exception.StatusCode);
+        _repositoryMock.Verify(repo => repo.TextRepository.CreateAsync(It.IsAny<Text>()), Times.Once);
+        _repositoryMock.Verify(repo => repo.SaveChangesAsync(), Times.Once);
+    }
+    
+    [Fact]
+    public async Task Handle_ShouldReturnTextDto_WhenChangeSavedAndTextDtoMapped()
+    {
+        // Arrange
+        var textCreateDto = new TextCreateDto();
+        var command = new CreateTextCommand(textCreateDto);
+        var text = new Text();
+        var textDto = new TextDto();
+
+        _mapperMock
+            .Setup(mapper => mapper.Map<Text>(It.IsAny<TextCreateDto>()))
+            .Returns(text);
+        _mapperMock
+            .Setup(mapper => mapper.Map<TextDto>(It.IsAny<Text>()))
+            .Returns(textDto);
+
+        _repositoryMock
+            .Setup(repo => repo.TextRepository.CreateAsync(It.IsAny<Text>()))
+            .ReturnsAsync(text);
+        _repositoryMock
+            .Setup(repo => repo.SaveChangesAsync())
+            .ReturnsAsync(1);
+        
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+        
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().Be(textDto);
+        _repositoryMock.Verify(repo => repo.TextRepository.CreateAsync(It.IsAny<Text>()), Times.Once);
+        _repositoryMock.Verify(repo => repo.SaveChangesAsync(), Times.Once);
+    }
+}


### PR DESCRIPTION
dev
## Summary of issue

Implement feature to add texts about streetcode

## Summary of change

- Added `TextCreateDto`
- Configured mapping from `TextCreateDto` to `Text`;
- Changed `CreateTextCommand` to accept `TextCreateDto` as a parameter and return result of type `TextDto`
- Add `Handle` method to proccess request and return the result ot throw an error
- Added unit tests for mapping config, handler and command validator.

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=50%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  PR meets all conventions
