### PR TITLE
fix/233/fix launch settings to open swagger ui on startup in Local env

### DIFF
--- a/Streetcode/Streetcode.WebApi/Properties/launchSettings.json
+++ b/Streetcode/Streetcode.WebApi/Properties/launchSettings.json
@@ -3,12 +3,13 @@
     "Streetcode_Local": {
       "commandName": "Project",
       "launchBrowser": true,
+      "launchUrl": "swagger",
       "environmentVariables": {
         "STREETCODE_ENVIRONMENT": "Local",
         "ASPNETCORE_ENVIRONMENT": "Local"
       },
       "dotnetRunMessages": true,
-      "applicationUrl": "http://localhost:5000;https://localhost:5001"
+      "applicationUrl": "https://localhost:5001;http://localhost:5000"
     },
 
     "Streetcode_Dev": {


### PR DESCRIPTION
dev
## Summary of issue

On project launch swagger ui in browser didn't open. Every time to write `/swagger/index.html` is inconvenient

## Summary of change

Adjust launch settings to open swagger ui on project startup when in Local environment. Also changed default port launch from http 5000 to https 5001 that is more secure


## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=50%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  PR meets all conventions
