### PR TITLE
feat/208/ add Authorize(Roles = Admin) attribute

### DIFF
--- a/Streetcode/Streetcode.WebApi/Controllers/Streetcode/TextContent/CommentController.cs
+++ b/Streetcode/Streetcode.WebApi/Controllers/Streetcode/TextContent/CommentController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
 using Streetcode.BLL.Dto.Streetcode.TextContent.Comment;
 using Streetcode.BLL.MediatR.Streetcode.Comment.Create;
 using Streetcode.BLL.MediatR.Streetcode.Comment.Delete;
@@ -17,6 +18,7 @@ public class CommentController : BaseApiController
     }
 
     [HttpDelete("{id:int}")]
+    [Authorize(Roles = "Admin")]
     public async Task<IActionResult> Delete([FromRoute] int id)
     {
         return HandleResult(await Mediator.Send(new DeleteCommentCommand(id)));


### PR DESCRIPTION
dev
## Summary of issue

Only admins must be able to delete comments

## Summary of change

Added `Authorize(Roles = Admin)` attribute to controller endpoint 

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=50%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  PR meets all conventions
