### PR TITLE
Attiribut has been changed and applied to the new opera edit

### DIFF
--- a/Streetcode/Streetcode.WebApi/Controllers/Streetcode/TextContent/CommentController.cs
+++ b/Streetcode/Streetcode.WebApi/Controllers/Streetcode/TextContent/CommentController.cs
@@ -7,6 +7,7 @@ using Streetcode.BLL.MediatR.Streetcode.Comment.Delete;
 using Streetcode.BLL.MediatR.Streetcode.Comment.GetAllCommentsWithReplies;
 using Streetcode.BLL.MediatR.Streetcode.Comment.GetByStreetcodeId;
 using Streetcode.BLL.MediatR.Streetcode.Comment.Update;
+using Streetcode.WebApi.Extensions.Attributes;
 
 namespace Streetcode.WebApi.Controllers.Streetcode.TextContent;
 

--- a/Streetcode/Streetcode.WebApi/Controllers/Streetcode/TextContent/CommentController.cs
+++ b/Streetcode/Streetcode.WebApi/Controllers/Streetcode/TextContent/CommentController.cs
@@ -7,7 +7,6 @@ using Streetcode.BLL.MediatR.Streetcode.Comment.Delete;
 using Streetcode.BLL.MediatR.Streetcode.Comment.GetAllCommentsWithReplies;
 using Streetcode.BLL.MediatR.Streetcode.Comment.GetByStreetcodeId;
 using Streetcode.BLL.MediatR.Streetcode.Comment.Update;
-using Streetcode.WebApi.Extensions.Attributes;
 
 namespace Streetcode.WebApi.Controllers.Streetcode.TextContent;
 
@@ -27,6 +26,7 @@ public class CommentController : BaseApiController
     }
 
     [HttpPut]
+    [AuthorizeRoleOrOwner("None")]
     public async Task<IActionResult> Update([FromBody] CommentUpdateDto commentDto)
     {
         return HandleResult(await Mediator.Send(new UpdateCommentCommand(commentDto)));

--- a/Streetcode/Streetcode.WebApi/Extensions/Attributes/AuthorizeRoleOrOwnerAttribute.cs
+++ b/Streetcode/Streetcode.WebApi/Extensions/Attributes/AuthorizeRoleOrOwnerAttribute.cs
@@ -5,6 +5,8 @@ using Streetcode.DAL.Repositories.Interfaces.Base;
 using System.Security.Claims;
 using System.Reflection;
 
+namespace Streetcode.WebApi.Extensions.Attributes;
+
 public class AuthorizeRoleOrOwnerAttribute : Attribute, IAsyncActionFilter
 {
     private readonly string _role;

--- a/Streetcode/Streetcode.XUnitTest/Extensions/AuthorizeRoleOrOwnerAttributeTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/Extensions/AuthorizeRoleOrOwnerAttributeTests.cs
@@ -9,6 +9,7 @@ using Streetcode.DAL.Entities.Streetcode.TextContent;
 using Microsoft.Extensions.DependencyInjection;
 using Streetcode.DAL.Repositories.Interfaces.Streetcode.TextContent;
 using Streetcode.BLL.Dto.Streetcode.TextContent.Comment;
+using Streetcode.WebApi.Extensions.Attributes;
 
 namespace Streetcode.XUnitTest.Extensions
 {

--- a/Streetcode/Streetcode.XUnitTest/Extensions/AuthorizeRoleOrOwnerAttributeTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/Extensions/AuthorizeRoleOrOwnerAttributeTests.cs
@@ -6,40 +6,59 @@ using System.Security.Claims;
 using Microsoft.AspNetCore.Mvc;
 using Streetcode.DAL.Repositories.Interfaces.Base;
 using Streetcode.DAL.Entities.Streetcode.TextContent;
-using Streetcode.BLL.Exceptions.CustomExceptions;
 using Microsoft.Extensions.DependencyInjection;
 using Streetcode.DAL.Repositories.Interfaces.Streetcode.TextContent;
-using Streetcode.WebApi.Extensions.Attributes;
+using Streetcode.BLL.Dto.Streetcode.TextContent.Comment;
 
 namespace Streetcode.XUnitTest.Extensions
 {
     public class AuthorizeRoleOrOwnerAttributeTests
     {
         [Fact]
-        public void OnAuthorization_UserNotAuthenticated_ReturnsUnauthorized()
+        public async Task OnActionExecutionAsync_UserNotAuthenticated_ReturnsUnauthorized()
         {
             // Arrange
             var attribute = new AuthorizeRoleOrOwnerAttribute("Admin");
             var httpContext = new DefaultHttpContext();
-            var authFilterContext = CreateAuthorizationFilterContext(httpContext);
 
             var mockUser = new ClaimsPrincipal(new ClaimsIdentity());
             httpContext.User = mockUser;
 
+            var actionContext = new ActionContext
+            {
+                HttpContext = httpContext,
+                RouteData = new Microsoft.AspNetCore.Routing.RouteData(),
+                ActionDescriptor = new Microsoft.AspNetCore.Mvc.Abstractions.ActionDescriptor()
+            };
+
+            var actionExecutingContext = new ActionExecutingContext(
+                actionContext,
+                new List<IFilterMetadata>(),
+                new Dictionary<string, object>(),
+                controller: null
+            );
+
+            var actionExecutedContext = new ActionExecutedContext(
+                actionContext,
+                new List<IFilterMetadata>(),
+                controller: null
+            );
+
+            var next = new ActionExecutionDelegate(() => Task.FromResult(actionExecutedContext));
+
             // Act
-            attribute.OnAuthorization(authFilterContext);
+            await attribute.OnActionExecutionAsync(actionExecutingContext, next);
 
             // Assert
-            Assert.IsType<UnauthorizedResult>(authFilterContext.Result);
+            Assert.IsType<UnauthorizedResult>(actionExecutingContext.Result);
         }
 
         [Fact]
-        public void OnAuthorization_UserHasRequiredRole_Authorized()
+        public async Task OnActionExecutionAsync_UserHasRequiredRole_Authorized()
         {
             // Arrange
             var attribute = new AuthorizeRoleOrOwnerAttribute("Admin");
             var httpContext = new DefaultHttpContext();
-            var authFilterContext = CreateAuthorizationFilterContext(httpContext);
 
             var claims = new List<Claim>
             {
@@ -50,20 +69,41 @@ namespace Streetcode.XUnitTest.Extensions
             var mockUser = new ClaimsPrincipal(identity);
             httpContext.User = mockUser;
 
+            var actionContext = new ActionContext
+            {
+                HttpContext = httpContext,
+                RouteData = new Microsoft.AspNetCore.Routing.RouteData(),
+                ActionDescriptor = new Microsoft.AspNetCore.Mvc.Abstractions.ActionDescriptor()
+            };
+
+            var actionExecutingContext = new ActionExecutingContext(
+                actionContext,
+                new List<IFilterMetadata>(),
+                new Dictionary<string, object>(),
+                controller: null
+            );
+
+            var actionExecutedContext = new ActionExecutedContext(
+                actionContext,
+                new List<IFilterMetadata>(),
+                controller: null
+            );
+
+            var next = new ActionExecutionDelegate(() => Task.FromResult(actionExecutedContext));
+
             // Act
-            attribute.OnAuthorization(authFilterContext);
+            await attribute.OnActionExecutionAsync(actionExecutingContext, next);
 
             // Assert
-            Assert.Null(authFilterContext.Result);
+            Assert.Null(actionExecutingContext.Result); 
         }
 
         [Fact]
-        public async Task OnAuthorizationAsync_UserIsOwner_Authorized()
+        public async Task OnActionExecutionAsync_UserIsOwner_Authorized()
         {
             // Arrange
             var attribute = new AuthorizeRoleOrOwnerAttribute("Admin");
             var httpContext = new DefaultHttpContext();
-            var authFilterContext = CreateAuthorizationFilterContext(httpContext);
 
             var claims = new List<Claim>
             {
@@ -73,7 +113,30 @@ namespace Streetcode.XUnitTest.Extensions
             var mockUser = new ClaimsPrincipal(identity);
             httpContext.User = mockUser;
 
-            authFilterContext.RouteData.Values["id"] = "10";
+            var routeData = new Microsoft.AspNetCore.Routing.RouteData();
+            routeData.Values["id"] = "10";
+
+            var actionContext = new ActionContext
+            {
+                HttpContext = httpContext,
+                RouteData = routeData,
+                ActionDescriptor = new Microsoft.AspNetCore.Mvc.Abstractions.ActionDescriptor()
+            };
+
+            var actionExecutingContext = new ActionExecutingContext(
+                actionContext,
+                new List<IFilterMetadata>(),
+                new Dictionary<string, object>(),
+                controller: null
+            );
+
+            var actionExecutedContext = new ActionExecutedContext(
+                actionContext,
+                new List<IFilterMetadata>(),
+                controller: null
+            );
+
+            var next = new ActionExecutionDelegate(() => Task.FromResult(actionExecutedContext));
 
             var mockRepoWrapper = new Mock<IRepositoryWrapper>();
             var mockCommentRepo = new Mock<ICommentRepository>();
@@ -90,30 +153,51 @@ namespace Streetcode.XUnitTest.Extensions
             httpContext.RequestServices = serviceProvider;
 
             // Act
-            attribute.OnAuthorization(authFilterContext);
+            await attribute.OnActionExecutionAsync(actionExecutingContext, next);
 
             // Assert
-            Assert.Null(authFilterContext.Result);
+            Assert.Null(actionExecutingContext.Result); 
         }
 
-
         [Fact]
-        public async Task OnAuthorizationAsync_UserNotAdminOrOwner_ReturnsForbid()
+        public async Task OnActionExecutionAsync_UserNotAdminOrOwner_ReturnsForbid()
         {
             // Arrange
             var attribute = new AuthorizeRoleOrOwnerAttribute("Admin");
             var httpContext = new DefaultHttpContext();
-            var authFilterContext = CreateAuthorizationFilterContext(httpContext);
 
             var claims = new List<Claim>
             {
-                new Claim(ClaimTypes.NameIdentifier, "2")
+                new Claim(ClaimTypes.NameIdentifier, "2") // UserId = 2
             };
             var identity = new ClaimsIdentity(claims, "TestAuthType");
             var mockUser = new ClaimsPrincipal(identity);
             httpContext.User = mockUser;
 
-            authFilterContext.RouteData.Values["id"] = "10";
+            var routeData = new Microsoft.AspNetCore.Routing.RouteData();
+            routeData.Values["id"] = "10";
+
+            var actionContext = new ActionContext
+            {
+                HttpContext = httpContext,
+                RouteData = routeData,
+                ActionDescriptor = new Microsoft.AspNetCore.Mvc.Abstractions.ActionDescriptor()
+            };
+
+            var actionExecutingContext = new ActionExecutingContext(
+                actionContext,
+                new List<IFilterMetadata>(),
+                new Dictionary<string, object>(),
+                controller: null
+            );
+
+            var actionExecutedContext = new ActionExecutedContext(
+                actionContext,
+                new List<IFilterMetadata>(),
+                controller: null
+            );
+
+            var next = new ActionExecutionDelegate(() => Task.FromResult(actionExecutedContext));
 
             var mockRepoWrapper = new Mock<IRepositoryWrapper>();
             var mockCommentRepo = new Mock<ICommentRepository>();
@@ -130,12 +214,76 @@ namespace Streetcode.XUnitTest.Extensions
             httpContext.RequestServices = serviceProvider;
 
             // Act
-            attribute.OnAuthorization(authFilterContext);
+            await attribute.OnActionExecutionAsync(actionExecutingContext, next);
 
             // Assert
-            Assert.IsType<ForbidResult>(authFilterContext.Result);
+            Assert.IsType<ForbidResult>(actionExecutingContext.Result);
         }
 
+        [Fact]
+        public async Task OnActionExecutionAsync_UserIsOwner_WithIdInBody_Authorized()
+        {
+            // Arrange
+            var attribute = new AuthorizeRoleOrOwnerAttribute("Admin");
+            var httpContext = new DefaultHttpContext();
+
+            var claims = new List<Claim>
+            {
+                new Claim(ClaimTypes.NameIdentifier, "1")
+            };
+            var identity = new ClaimsIdentity(claims, "TestAuthType");
+            var mockUser = new ClaimsPrincipal(identity);
+            httpContext.User = mockUser;
+
+            var commentDto = new CommentUpdateDto { Id = 10, CommentContent = "Updated content" };
+
+            var actionArguments = new Dictionary<string, object>
+            {
+                { "commentDto", commentDto }
+            };
+
+            var actionContext = new ActionContext
+            {
+                HttpContext = httpContext,
+                RouteData = new Microsoft.AspNetCore.Routing.RouteData(),
+                ActionDescriptor = new Microsoft.AspNetCore.Mvc.Abstractions.ActionDescriptor()
+            };
+
+            var actionExecutingContext = new ActionExecutingContext(
+                actionContext,
+                new List<IFilterMetadata>(),
+                actionArguments,
+                controller: null
+            );
+
+            var actionExecutedContext = new ActionExecutedContext(
+                actionContext,
+                new List<IFilterMetadata>(),
+                controller: null
+            );
+
+            var next = new ActionExecutionDelegate(() => Task.FromResult(actionExecutedContext));
+
+            var mockRepoWrapper = new Mock<IRepositoryWrapper>();
+            var mockCommentRepo = new Mock<ICommentRepository>();
+
+            mockRepoWrapper.Setup(r => r.CommentRepository).Returns(mockCommentRepo.Object);
+            mockCommentRepo.Setup(r => r.GetFirstOrDefaultAsync(
+                It.IsAny<System.Linq.Expressions.Expression<Func<Comment, bool>>>(),
+                null))
+                .ReturnsAsync(new Comment { Id = 10, UserId = 1 });
+
+            var serviceProvider = new ServiceCollection()
+                .AddSingleton(mockRepoWrapper.Object)
+                .BuildServiceProvider();
+            httpContext.RequestServices = serviceProvider;
+
+            // Act
+            await attribute.OnActionExecutionAsync(actionExecutingContext, next);
+
+            // Assert
+            Assert.Null(actionExecutingContext.Result);
+        }
 
         private AuthorizationFilterContext CreateAuthorizationFilterContext(HttpContext httpContext)
         {


### PR DESCRIPTION
dev
## Summary of issue

Comments can only be changed by those who created it 

## Summary of change

Changed custom validation attribute to check who created the comment 
It's also reused in the new endpoint. 
Tests modified to fit the new attribute 

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=50%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  PR meets all conventions
