### PR TITLE
fix/301/allow any origin

### DIFF
--- a/Streetcode/Streetcode.WebApi/Extensions/ServiceCollectionExtensions.cs
+++ b/Streetcode/Streetcode.WebApi/Extensions/ServiceCollectionExtensions.cs
@@ -100,7 +100,7 @@ public static class ServiceCollectionExtensions
         {
             opt.AddDefaultPolicy(policy =>
             {
-                policy.WithOrigins(corsConfig?.AllowedOrigins?.ToArray() ?? Array.Empty<string>())
+                policy.AllowAnyOrigin()
                     .WithHeaders(corsConfig?.AllowedHeaders?.ToArray() ?? Array.Empty<string>())
                     .WithMethods(corsConfig?.AllowedMethods?.ToArray() ?? Array.Empty<string>())
                     .SetPreflightMaxAge(TimeSpan.FromSeconds(corsConfig?.PreflightMaxAge ?? 86400));


### PR DESCRIPTION
dev
## Summary of issue

Frontend can not make requests to backend due to cors policy

## Summary of change

Only solution for the problem was fiund to allow any origin.


## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=50%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  PR meets all conventions
